### PR TITLE
fix(security): add adventure ID validation to prevent path traversal

### DIFF
--- a/backend/src/validation.ts
+++ b/backend/src/validation.ts
@@ -1,0 +1,97 @@
+// Input validation for Adventure Engine
+// Prevents path traversal and other injection attacks
+
+import { resolve, join, normalize } from "node:path";
+
+/**
+ * Validation result with error message if invalid
+ */
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Validate an adventure ID to prevent path traversal attacks.
+ *
+ * Adventure IDs must:
+ * - Not be empty
+ * - Not contain path separators (/ or \)
+ * - Not be "." or ".."
+ * - Not contain null bytes
+ *
+ * @param id Adventure ID to validate
+ * @returns ValidationResult indicating if ID is safe
+ */
+export function validateAdventureId(id: string): ValidationResult {
+  // Check for empty/whitespace-only ID
+  if (!id || id.trim().length === 0) {
+    return { valid: false, error: "Adventure ID cannot be empty" };
+  }
+
+  // Check for null bytes (can cause truncation in some systems)
+  if (id.includes("\0")) {
+    return { valid: false, error: "Adventure ID contains invalid characters" };
+  }
+
+  // Check for path separators
+  if (id.includes("/") || id.includes("\\")) {
+    return { valid: false, error: "Adventure ID cannot contain path separators" };
+  }
+
+  // Check for directory traversal patterns
+  if (id === "." || id === "..") {
+    return { valid: false, error: "Adventure ID cannot be a relative directory reference" };
+  }
+
+  // Additional check: ensure ID doesn't decode to dangerous values
+  // (handles URL-encoded path traversal attempts like %2F or %2e%2e)
+  try {
+    const decoded = decodeURIComponent(id);
+    if (decoded !== id) {
+      // If decoding changes the value, re-validate the decoded version
+      if (decoded.includes("/") || decoded.includes("\\") ||
+          decoded === "." || decoded === "..") {
+        return { valid: false, error: "Adventure ID contains encoded path characters" };
+      }
+    }
+  } catch {
+    // decodeURIComponent throws on malformed input - that's fine, the raw ID is safe
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Safely resolve an adventure directory path, ensuring it stays within the base directory.
+ *
+ * This provides defense-in-depth against path traversal, even if the ID passes validation.
+ *
+ * @param baseDir Base adventures directory
+ * @param adventureId Adventure ID
+ * @returns Safe resolved path, or null if path would escape base directory
+ */
+export function safeResolvePath(baseDir: string, adventureId: string): string | null {
+  // First validate the ID
+  const validation = validateAdventureId(adventureId);
+  if (!validation.valid) {
+    return null;
+  }
+
+  // Resolve both paths to absolute
+  const resolvedBase = resolve(baseDir);
+  const resolvedPath = resolve(join(baseDir, adventureId));
+
+  // Normalize both for consistent comparison
+  const normalizedBase = normalize(resolvedBase);
+  const normalizedPath = normalize(resolvedPath);
+
+  // Ensure the resolved path is within the base directory
+  // The resolved path must start with the base path plus a separator
+  if (!normalizedPath.startsWith(normalizedBase + "/") &&
+      normalizedPath !== normalizedBase) {
+    return null;
+  }
+
+  return resolvedPath;
+}

--- a/backend/tests/unit/adventure-state.test.ts
+++ b/backend/tests/unit/adventure-state.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdir, rm, writeFile, readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { randomUUID } from "node:crypto";
 import { AdventureStateManager } from "../../src/adventure-state";
 import type { NarrativeEntry } from "../../../shared/protocol";
@@ -140,7 +140,8 @@ describe("AdventureStateManager", () => {
       if (!result.success) {
         expect(result.error.type).toBe("CORRUPTED");
         if (result.error.type === "CORRUPTED") {
-          expect(result.error.path).toBe(statePath);
+          // Compare absolute paths since safeResolvePath returns absolute paths
+          expect(result.error.path).toBe(resolve(statePath));
         }
       }
     });
@@ -159,7 +160,8 @@ describe("AdventureStateManager", () => {
       if (!result.success) {
         expect(result.error.type).toBe("CORRUPTED");
         if (result.error.type === "CORRUPTED") {
-          expect(result.error.path).toBe(historyPath);
+          // Compare absolute paths since safeResolvePath returns absolute paths
+          expect(result.error.path).toBe(resolve(historyPath));
         }
       }
     });

--- a/backend/tests/unit/validation.test.ts
+++ b/backend/tests/unit/validation.test.ts
@@ -1,0 +1,158 @@
+// Validation Tests
+// Unit tests for adventure ID validation and path traversal prevention
+
+import { describe, test, expect } from "bun:test";
+import { validateAdventureId, safeResolvePath } from "../../src/validation";
+
+describe("validateAdventureId()", () => {
+  describe("valid IDs", () => {
+    test("accepts UUID format", () => {
+      const result = validateAdventureId(
+        "550e8400-e29b-41d4-a716-446655440000"
+      );
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    test("accepts simple alphanumeric ID", () => {
+      const result = validateAdventureId("adventure123");
+      expect(result.valid).toBe(true);
+    });
+
+    test("accepts ID with hyphens", () => {
+      const result = validateAdventureId("my-adventure-2024");
+      expect(result.valid).toBe(true);
+    });
+
+    test("accepts ID with underscores", () => {
+      const result = validateAdventureId("my_adventure_2024");
+      expect(result.valid).toBe(true);
+    });
+
+    test("accepts single character ID", () => {
+      const result = validateAdventureId("a");
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("path traversal attempts", () => {
+    test("rejects forward slash", () => {
+      const result = validateAdventureId("../etc/passwd");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("path separator");
+    });
+
+    test("rejects backslash", () => {
+      const result = validateAdventureId("..\\windows\\system32");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("path separator");
+    });
+
+    test("rejects double dot", () => {
+      const result = validateAdventureId("..");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("relative directory");
+    });
+
+    test("rejects single dot", () => {
+      const result = validateAdventureId(".");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("relative directory");
+    });
+
+    test("rejects URL-encoded forward slash", () => {
+      const result = validateAdventureId("..%2Fetc%2Fpasswd");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("encoded path");
+    });
+
+    test("rejects URL-encoded backslash", () => {
+      const result = validateAdventureId("..%5Cwindows");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("encoded path");
+    });
+
+    test("rejects URL-encoded double dot", () => {
+      const result = validateAdventureId("%2e%2e");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("encoded path");
+    });
+
+    test("rejects mixed path traversal", () => {
+      const result = validateAdventureId("foo/../bar");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("path separator");
+    });
+  });
+
+  describe("invalid inputs", () => {
+    test("rejects empty string", () => {
+      const result = validateAdventureId("");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("empty");
+    });
+
+    test("rejects whitespace-only string", () => {
+      const result = validateAdventureId("   ");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("empty");
+    });
+
+    test("rejects null byte", () => {
+      const result = validateAdventureId("adventure\0id");
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain("invalid characters");
+    });
+  });
+});
+
+describe("safeResolvePath()", () => {
+  const baseDir = "/home/user/adventures";
+
+  describe("valid paths", () => {
+    test("resolves valid adventure ID", () => {
+      const result = safeResolvePath(baseDir, "adventure123");
+      expect(result).toBe("/home/user/adventures/adventure123");
+    });
+
+    test("resolves UUID-style ID", () => {
+      const result = safeResolvePath(
+        baseDir,
+        "550e8400-e29b-41d4-a716-446655440000"
+      );
+      expect(result).toBe(
+        "/home/user/adventures/550e8400-e29b-41d4-a716-446655440000"
+      );
+    });
+  });
+
+  describe("path traversal prevention", () => {
+    test("returns null for path with forward slash", () => {
+      const result = safeResolvePath(baseDir, "../etc/passwd");
+      expect(result).toBeNull();
+    });
+
+    test("returns null for double dot", () => {
+      const result = safeResolvePath(baseDir, "..");
+      expect(result).toBeNull();
+    });
+
+    test("returns null for single dot", () => {
+      const result = safeResolvePath(baseDir, ".");
+      expect(result).toBeNull();
+    });
+
+    test("returns null for empty string", () => {
+      const result = safeResolvePath(baseDir, "");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("relative base directory", () => {
+    test("resolves with relative base", () => {
+      const result = safeResolvePath("./adventures", "adventure123");
+      expect(result).not.toBeNull();
+      expect(result).toContain("adventures/adventure123");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `validateAdventureId()` to check for path separators, `..`, `.`, null bytes, and URL-encoded attacks
- Add `safeResolvePath()` for defense-in-depth path resolution verification
- Apply validation at REST endpoint, WebSocket handler, and AdventureStateManager entry points

## Test plan

- [x] Unit tests for validation module (23 tests covering valid IDs, path traversal attacks, URL-encoded attacks)
- [x] Updated adventure-state tests to expect absolute paths
- [x] TypeScript typecheck passes
- [x] ESLint clean for modified files

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)