### PR TITLE
fix(security): add Origin header validation for WebSocket CSRF protection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ Catalog-first strategy: `ImageCatalogService` searches `/assets/backgrounds` bef
 - `ADVENTURES_DIR` (default ./adventures)
 - `REPLICATE_API_TOKEN` (required for image generation)
 - `MOCK_SDK` (set "true" for testing without Agent SDK)
+- `ALLOWED_ORIGINS` (comma-separated list, defaults to `http://localhost:5173,http://localhost:3000`)
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

- Adds Origin header validation to WebSocket upgrade endpoint to prevent cross-site WebSocket hijacking (CSRF)
- Configurable via `ALLOWED_ORIGINS` env var (defaults to localhost:5173 and localhost:3000)
- Returns 403 Forbidden for requests with invalid or missing Origin headers

Closes #3

## Test plan

- [x] Unit tests for `isAllowedOrigin()` function (7 test cases)
- [x] Integration tests for WebSocket endpoint CSRF rejection (3 test cases)
- [x] All 27 tests passing
- [ ] Manual test: verify frontend still connects normally
- [ ] Manual test: verify requests from other origins are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)