### PR TITLE
fix(security): restrict state file permissions to owner-only (#4)

### DIFF
--- a/backend/src/adventure-state.ts
+++ b/backend/src/adventure-state.ts
@@ -69,9 +69,9 @@ export class AdventureStateManager {
 
     this.history = { entries: [] };
 
-    // Create adventure directory
+    // Create adventure directory (mode 0o700 = owner only access)
     const adventureDir = this.getAdventureDir(adventureId);
-    await mkdir(adventureDir, { recursive: true });
+    await mkdir(adventureDir, { recursive: true, mode: 0o700 });
 
     // Save initial state
     await this.save();
@@ -196,26 +196,26 @@ export class AdventureStateManager {
     const stateTempPath = join(adventureDir, ".state.json.tmp");
     const historyTempPath = join(adventureDir, ".history.json.tmp");
 
-    // Ensure directory exists
-    await mkdir(adventureDir, { recursive: true });
+    // Ensure directory exists (mode 0o700 = owner only access)
+    await mkdir(adventureDir, { recursive: true, mode: 0o700 });
 
     // Update last active timestamp
     this.state.lastActiveAt = new Date().toISOString();
 
     try {
-      // Atomic write for state.json
+      // Atomic write for state.json (mode 0o600 = owner read/write only)
       await writeFile(
         stateTempPath,
         JSON.stringify(this.state, null, 2),
-        "utf-8"
+        { encoding: "utf-8", mode: 0o600 }
       );
       await rename(stateTempPath, statePath);
 
-      // Atomic write for history.json
+      // Atomic write for history.json (mode 0o600 = owner read/write only)
       await writeFile(
         historyTempPath,
         JSON.stringify(this.history, null, 2),
-        "utf-8"
+        { encoding: "utf-8", mode: 0o600 }
       );
       await rename(historyTempPath, historyPath);
     } catch (error) {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -84,11 +84,13 @@ const backgroundImageService = new BackgroundImageService(
   }
 );
 
-// Initialize image generator service (async)
-imageGeneratorService.initialize().catch((err) => {
+// Initialize image generator service
+try {
+  imageGeneratorService.initialize();
+} catch (err) {
   console.warn("[Server] Image generator initialization failed:", err);
   console.warn("[Server] Image generation will be unavailable, catalog/fallback only");
-});
+}
 
 // Health check (used by launch script to verify server is ready)
 app.get("/api/health", (c) => c.text("Adventure Engine Backend"));

--- a/backend/src/services/image-generator.ts
+++ b/backend/src/services/image-generator.ts
@@ -149,7 +149,7 @@ export class ImageGeneratorService {
    *
    * @throws Error if API token is not set
    */
-  async initialize(): Promise<void> {
+  initialize(): void {
     if (!this.apiToken) {
       throw new Error(
         "REPLICATE_API_TOKEN environment variable is required for image generation"
@@ -262,7 +262,7 @@ export class ImageGeneratorService {
    *
    * Should be called when shutting down the service.
    */
-  async close(): Promise<void> {
+  close(): void {
     this.replicate = null;
   }
 
@@ -440,7 +440,7 @@ export class ImageGeneratorService {
    */
   private extractImageUrl(output: unknown): string | null {
     if (Array.isArray(output) && output.length > 0) {
-      const first = output[0];
+      const first: unknown = output[0];
 
       // FileOutput object with url() method
       if (typeof first === "object" && first !== null && "url" in first) {


### PR DESCRIPTION
## Summary
- Set directory permissions to `0o700` (owner rwx only) for adventure directories
- Set file permissions to `0o600` (owner rw only) for `state.json` and `history.json`
- Add unit tests verifying file permissions are correctly applied

Also fixes pre-existing issues discovered during implementation:
- Convert `ImageGeneratorService.initialize/close` from async to sync (no await needed)
- Fix test mocks to properly target Replicate SDK instead of MCP SDK
- Update `BackgroundImageService` tests to match current implementation (glob discovery)

Closes #4

## Test plan
- [x] All 201 unit tests pass
- [x] Lint passes
- [x] TypeScript type checking passes
- [x] New permission tests verify 0o700 for directories, 0o600 for files
- [ ] Manual verification: create adventure and check `ls -la` on state files

🤖 Generated with [Claude Code](https://claude.com/claude-code)