### PR TITLE
fix(AdventureMenu): handle promise rejections from new adventure button

### DIFF
--- a/frontend/src/components/AdventureMenu.tsx
+++ b/frontend/src/components/AdventureMenu.tsx
@@ -134,7 +134,11 @@ export function AdventureMenu({ onAdventureStart }: AdventureMenuProps) {
 
         <button
           onClick={() => {
-            void handleNewAdventure();
+            handleNewAdventure().catch((err: unknown) => {
+              setError(
+                err instanceof Error ? err.message : "An unexpected error occurred"
+              );
+            });
           }}
           disabled={isLoading}
           className="adventure-menu__button adventure-menu__button--new"

--- a/frontend/tests/unit/AdventureMenu.test.tsx
+++ b/frontend/tests/unit/AdventureMenu.test.tsx
@@ -117,6 +117,20 @@ describe("AdventureMenu", () => {
         expect(screen.getByText("Server error")).toBeInTheDocument();
       });
     });
+
+    test("handles promise rejections without silently swallowing them", async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(fetch).mockRejectedValueOnce(new Error("Network failure"));
+
+      render(<AdventureMenu onAdventureStart={mockOnAdventureStart} />);
+
+      await user.click(screen.getByRole("button", { name: /new adventure/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Network failure")).toBeInTheDocument();
+      });
+    });
   });
 
   describe("resume adventure", () => {


### PR DESCRIPTION
## Summary
- Replace `void handleNewAdventure()` with explicit `.catch()` handler
- Errors are now displayed to users instead of being silently swallowed
- Added test coverage for promise rejection handling

Fixes #32

## Test plan
- [x] New test: "handles promise rejections without silently swallowing them"
- [x] All existing AdventureMenu tests pass (11 tests)
- [x] Frontend typecheck passes
- [x] Frontend lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)