### PR TITLE
feat(logging): enable file logging by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Catalog-first strategy: `ImageCatalogService` searches `/assets/backgrounds` bef
 - `MOCK_SDK` (set "true" for testing without Agent SDK)
 - `ALLOWED_ORIGINS` (comma-separated list, defaults to `http://localhost:5173,http://localhost:3000`)
 - `LOG_LEVEL` (default "info") - Set log verbosity: "debug", "info", "warn", "error"
-- `LOG_FILE` (default unset) - Set to "true" to enable rotating file logs in `backend/logs/`
+- `LOG_FILE` (default enabled) - Set to "false" to disable rotating file logs in `backend/logs/`
 - `NODE_ENV` (default unset) - Set to "production" for JSON log output, otherwise uses pretty format
 
 ## Code Style


### PR DESCRIPTION
## Summary
- Change LOG_FILE default from opt-in to opt-out (file logs now enabled by default)
- Fix pino error: disable custom formatters when using multi-target transport
- Logs automatically created in `backend/logs/` with daily rotation and 10MB size limit

## Test plan
- [x] Verify logs directory is created automatically on server start
- [x] Verify log files contain expected output
- [x] Verify tests pass with `LOG_FILE=false`
- [x] Verify typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)