### PR TITLE
fix(backend): validate PROJECT_DIR at session initialization

### DIFF
--- a/backend/tests/unit/game-session.test.ts
+++ b/backend/tests/unit/game-session.test.ts
@@ -104,6 +104,48 @@ describe("GameSession", () => {
       expect(result.error).toBeDefined();
       expect(result.error).toContain("not found");
     });
+
+    test("fails when PROJECT_DIR is not set", async () => {
+      const { ws } = createMockWS();
+      const session = new GameSession(ws, stateManager);
+
+      // Temporarily unset PROJECT_DIR
+      const originalProjectDir = process.env.PROJECT_DIR;
+      delete process.env.PROJECT_DIR;
+
+      try {
+        const result = await session.initialize(adventureId, sessionToken);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.error).toContain("PROJECT_DIR");
+        expect(result.error).toContain("not set");
+      } finally {
+        // Restore PROJECT_DIR
+        process.env.PROJECT_DIR = originalProjectDir;
+      }
+    });
+
+    test("fails when PROJECT_DIR directory does not exist", async () => {
+      const { ws } = createMockWS();
+      const session = new GameSession(ws, stateManager);
+
+      // Temporarily set PROJECT_DIR to non-existent directory
+      const originalProjectDir = process.env.PROJECT_DIR;
+      process.env.PROJECT_DIR = "./non-existent-directory-12345";
+
+      try {
+        const result = await session.initialize(adventureId, sessionToken);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toBeDefined();
+        expect(result.error).toContain("PROJECT_DIR");
+        expect(result.error).toContain("does not exist");
+      } finally {
+        // Restore PROJECT_DIR
+        process.env.PROJECT_DIR = originalProjectDir;
+      }
+    });
   });
 
   describe("handleInput() - Queue Management", () => {


### PR DESCRIPTION
## Summary

- Add fail-fast validation for `PROJECT_DIR` environment variable during GameSession initialization
- Check that `PROJECT_DIR` is set (not undefined/empty)
- Validate that the directory exists using `existsSync`
- Return descriptive error messages for each failure case

This provides clearer error messages when the environment is misconfigured, failing at session initialization rather than at query time.

## Test plan

- [x] Unit tests added for both validation scenarios
- [x] All 298 backend unit tests pass
- [x] All 84 frontend unit tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes

Fixes #25, Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)