### PR TITLE
feat(skill): cascade .env loading in launch-world script

### DIFF
--- a/corvran/skills/enter-world/scripts/launch-world.sh
+++ b/corvran/skills/enter-world/scripts/launch-world.sh
@@ -23,11 +23,29 @@ fi
 # Convert to absolute path (required for SDK cwd)
 PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
 
-# Source .env file from project directory if it exists
+# Source .env files (engine defaults first, then project overrides)
+DEBUG="${DEBUG:-}"
+set -a  # Export all variables
+# Engine backend .env (development defaults)
+if [[ -f "$ENGINE_DIR/backend/.env" ]]; then
+    source "$ENGINE_DIR/backend/.env"
+    [[ -n "$DEBUG" ]] && echo "[env] Sourced: $ENGINE_DIR/backend/.env" >&2
+fi
+# Engine root .env
+if [[ -f "$ENGINE_DIR/.env" ]]; then
+    source "$ENGINE_DIR/.env"
+    [[ -n "$DEBUG" ]] && echo "[env] Sourced: $ENGINE_DIR/.env" >&2
+fi
+# Project directory .env (adventure-specific overrides)
 if [[ -f "$PROJECT_DIR/.env" ]]; then
-    set -a  # Export all variables
     source "$PROJECT_DIR/.env"
-    set +a
+    [[ -n "$DEBUG" ]] && echo "[env] Sourced: $PROJECT_DIR/.env" >&2
+fi
+set +a
+
+# Debug: confirm critical env vars (without exposing values)
+if [[ -n "$DEBUG" ]]; then
+    [[ -n "${REPLICATE_API_TOKEN:-}" ]] && echo "[env] REPLICATE_API_TOKEN is set" >&2 || echo "[env] WARNING: REPLICATE_API_TOKEN is NOT set" >&2
 fi
 
 # Log file for headless operation


### PR DESCRIPTION
## Summary
- Source .env files from multiple locations with proper precedence (engine backend → engine root → project directory)
- Later sources override earlier ones, allowing adventure worlds to customize settings while inheriting engine defaults
- Add optional `DEBUG=1` mode for troubleshooting env loading issues

## Test plan
- [x] Verify .env sourcing from project directory still works
- [ ] Test DEBUG=1 output shows sourced files and token status
- [ ] Confirm environment variables are passed to backend server

🤖 Generated with [Claude Code](https://claude.com/claude-code)