### PR TITLE
feat(frontend): add React Error Boundary to catch render errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,36 +2,40 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Package Manager
+
+**This project uses `bun`, not npm.** Always use `bun run`, `bun test`, `bun add`, etc.
+
 ## Build & Development Commands
 
-**Backend** (in `/backend`, uses Bun):
+**Backend** (in `/backend`):
 ```bash
-npm run dev              # Watch mode with hot reload
-npm run test             # All tests (unit + integration)
-npm run test:unit        # Unit tests only
+bun run dev              # Watch mode with hot reload
+bun run test             # All tests (unit + integration)
+bun run test:unit        # Unit tests only
 bun test tests/unit/game-session.test.ts  # Single test file
-npm run typecheck        # TypeScript validation
-npm run lint             # ESLint
+bun run typecheck        # TypeScript validation
+bun run lint             # ESLint
 ```
 
 **Frontend** (in `/frontend`, uses Vite + Vitest):
 ```bash
-npm run dev              # Vite dev server (port 5173)
-npm run test             # Run tests once
-npm run test:watch       # Watch mode
-npm run test -- useWebSocket.test.tsx  # Single test file
-npm run typecheck
-npm run lint
+bun run dev              # Vite dev server (port 5173)
+bun run test             # Run tests once
+bun run test:watch       # Watch mode
+bun run test -- useWebSocket.test.tsx  # Single test file
+bun run typecheck
+bun run lint
 ```
 
 **E2E** (in `/e2e`, uses Playwright):
 ```bash
-npm test                 # Run tests (starts backend + frontend automatically)
-npm run test:headed      # Visible browser
-npm run test:debug       # Debug mode
+bun test                 # Run tests (starts backend + frontend automatically)
+bun run test:headed      # Visible browser
+bun run test:debug       # Debug mode
 ```
 
-**Development Workflow**: Run backend (`cd backend && npm run dev`) and frontend (`cd frontend && npm run dev`) in separate terminals.
+**Development Workflow**: Run backend (`cd backend && bun run dev`) and frontend (`cd frontend && bun run dev`) in separate terminals.
 
 ## Architecture
 

--- a/frontend/src/components/ErrorBoundary.css
+++ b/frontend/src/components/ErrorBoundary.css
@@ -1,0 +1,55 @@
+.error-boundary {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: var(--spacing-xl);
+  background-color: var(--color-background);
+}
+
+.error-boundary__content {
+  max-width: 500px;
+  text-align: center;
+  padding: var(--spacing-xl);
+  background-color: var(--color-surface);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+}
+
+.error-boundary__title {
+  margin: 0 0 var(--spacing-md) 0;
+  font-size: 1.5rem;
+  color: var(--color-error);
+}
+
+.error-boundary__message {
+  margin: 0 0 var(--spacing-lg) 0;
+  color: var(--color-text-secondary);
+}
+
+.error-boundary__details {
+  margin-bottom: var(--spacing-lg);
+  text-align: left;
+}
+
+.error-boundary__details summary {
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.error-boundary__details pre {
+  margin: var(--spacing-sm) 0 0 0;
+  padding: var(--spacing-md);
+  background-color: var(--color-error-bg);
+  color: var(--color-error);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-sm);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.error-boundary__retry {
+  min-width: 120px;
+}

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,67 @@
+import { Component, type ReactNode, type ErrorInfo } from "react";
+import "./ErrorBoundary.css";
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("ErrorBoundary caught an error:", error, errorInfo);
+  }
+
+  handleRetry = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="error-boundary" role="alert" data-testid="error-boundary">
+          <div className="error-boundary__content">
+            <h1 className="error-boundary__title">Something went wrong</h1>
+            <p className="error-boundary__message">
+              The application encountered an unexpected error.
+            </p>
+            {this.state.error && (
+              <details className="error-boundary__details">
+                <summary>Error details</summary>
+                <pre>{this.state.error.message}</pre>
+              </details>
+            )}
+            <button
+              onClick={this.handleRetry}
+              className="btn btn--primary error-boundary__retry"
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -2,6 +2,8 @@ export { AdventureMenu } from "./AdventureMenu";
 export type { AdventureMenuProps } from "./AdventureMenu";
 export { ConnectionStatus } from "./ConnectionStatus";
 export type { ConnectionStatusProps } from "./ConnectionStatus";
+export { ErrorBoundary } from "./ErrorBoundary";
+export type { ErrorBoundaryProps } from "./ErrorBoundary";
 export { InputField } from "./InputField";
 export type { InputFieldProps } from "./InputField";
 export { NarrativeEntry } from "./NarrativeEntry";

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,16 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { ErrorBoundary } from "./components";
 import "./index.css";
 
 const root = document.getElementById("root");
 if (root) {
   createRoot(root).render(
     <StrictMode>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </StrictMode>
   );
 }

--- a/frontend/tests/unit/ErrorBoundary.test.tsx
+++ b/frontend/tests/unit/ErrorBoundary.test.tsx
@@ -1,0 +1,165 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ErrorBoundary } from "../../src/components/ErrorBoundary";
+
+// Component that throws an error
+function ThrowingComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Test error message");
+  }
+  return <div>Normal content</div>;
+}
+
+describe("ErrorBoundary", () => {
+  beforeEach(() => {
+    // Suppress console.error for cleaner test output
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  describe("when no error occurs", () => {
+    test("renders children normally", () => {
+      render(
+        <ErrorBoundary>
+          <div>Child content</div>
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText("Child content")).toBeInTheDocument();
+    });
+
+    test("does not show error UI", () => {
+      render(
+        <ErrorBoundary>
+          <div>Child content</div>
+        </ErrorBoundary>
+      );
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when an error occurs", () => {
+    test("renders error UI instead of children", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+      expect(screen.queryByText("Normal content")).not.toBeInTheDocument();
+    });
+
+    test("displays error message in details", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText("Test error message")).toBeInTheDocument();
+    });
+
+    test("logs error to console", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow />
+        </ErrorBoundary>
+      );
+
+      expect(console.error).toHaveBeenCalledWith(
+        "ErrorBoundary caught an error:",
+        expect.any(Error),
+        expect.objectContaining({
+          componentStack: expect.any(String) as unknown,
+        })
+      );
+    });
+
+    test("renders retry button", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow />
+        </ErrorBoundary>
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Try Again" })
+      ).toBeInTheDocument();
+    });
+
+    test("retry button resets error state", async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow />
+        </ErrorBoundary>
+      );
+
+      // Error UI should be visible
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      // Re-render with non-throwing component before clicking retry
+      rerender(
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow={false} />
+        </ErrorBoundary>
+      );
+
+      // Click retry
+      await user.click(screen.getByRole("button", { name: "Try Again" }));
+
+      // Should now show normal content
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(screen.getByText("Normal content")).toBeInTheDocument();
+    });
+  });
+
+  describe("custom fallback", () => {
+    test("renders custom fallback when provided", () => {
+      render(
+        <ErrorBoundary fallback={<div>Custom error UI</div>}>
+          <ThrowingComponent shouldThrow />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText("Custom error UI")).toBeInTheDocument();
+      expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+    });
+
+    test("does not render custom fallback when no error", () => {
+      render(
+        <ErrorBoundary fallback={<div>Custom error UI</div>}>
+          <div>Normal content</div>
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByText("Normal content")).toBeInTheDocument();
+      expect(screen.queryByText("Custom error UI")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    test("error UI has alert role", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    test("error UI has test id for e2e testing", () => {
+      render(
+        <ErrorBoundary>
+          <ThrowingComponent shouldThrow />
+        </ErrorBoundary>
+      );
+
+      expect(screen.getByTestId("error-boundary")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add ErrorBoundary component that catches render errors and displays user-friendly error UI instead of crashing the app
- Wrap App component with ErrorBoundary in main.tsx
- Add comprehensive unit tests (11 tests)
- Update CLAUDE.md to clarify bun usage and fix all example commands from npm to bun

## Features

- Catches errors in render phase, lifecycle methods, and constructors
- Displays error message with collapsible details section
- Provides "Try Again" button for recovery
- Supports custom fallback UI via `fallback` prop
- Logs errors to console for debugging
- Accessible (role="alert", data-testid for e2e)

## Test plan

- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] All 95 frontend tests pass (11 new ErrorBoundary tests)
- [x] Pre-commit hook passes (backend + frontend)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)