### PR TITLE
fix(backend): add max WebSocket connection limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Catalog-first strategy: `ImageCatalogService` searches `/assets/backgrounds` bef
 - `LOG_LEVEL` (default "info") - Set log verbosity: "debug", "info", "warn", "error"
 - `LOG_FILE` (default enabled) - Set to "false" to disable rotating file logs in `backend/logs/`
 - `NODE_ENV` (default unset) - Set to "production" for JSON log output, otherwise uses pretty format
+- `MAX_CONNECTIONS` (default 100) - Maximum concurrent WebSocket connections
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

- Adds `MAX_CONNECTIONS` environment variable (default 100) to prevent resource exhaustion
- Rejects new WebSocket connections when limit is reached with error code 1013 ("Try Again Later")
- Sends retryable error message to client before closing
- Validates env var input (falls back to default for invalid values like `NaN`)
- Adds `getConnectionCount()` helper for monitoring and testing

## Test plan

- [x] Backend typecheck passes
- [x] Backend lint passes  
- [x] All 331 backend tests pass
- [ ] Manual test: Start server and verify connections work normally
- [ ] Manual test: Set `MAX_CONNECTIONS=2` and verify third connection is rejected

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)