### PR TITLE
fix(plugin): add cleanup/shutdown mechanism to launch-world.sh

### DIFF
--- a/corvran/skills/enter-world/scripts/stop-world.sh
+++ b/corvran/skills/enter-world/scripts/stop-world.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 #
 # Stop the Adventure Engine application
-# Usage: stop-world.sh <project-directory>
+# Usage: stop-world.sh [project-directory]
 #
-# This script stops a running Adventure Engine server by reading
-# the PID file created by launch-world.sh.
+# Reads the PID file from the project directory and stops the server.
 
 set -euo pipefail
 
 PROJECT_DIR="${1:-.}"
 
-# Validate project directory exists
-if [[ ! -d "$PROJECT_DIR" ]]; then
+# Convert to absolute path if exists
+if [[ -d "$PROJECT_DIR" ]]; then
+    PROJECT_DIR="$(cd "$PROJECT_DIR" && pwd)"
+else
     echo "Error: Project directory does not exist: $PROJECT_DIR" >&2
     exit 1
 fi
@@ -19,49 +20,72 @@ fi
 PID_FILE="$PROJECT_DIR/.adventure-engine.pid"
 LOG_FILE="$PROJECT_DIR/.adventure-engine.log"
 
-# Check if PID file exists
 if [[ ! -f "$PID_FILE" ]]; then
-    echo "No running Adventure Engine found (no PID file at $PID_FILE)"
+    echo "No running Adventure Engine found (PID file not found: $PID_FILE)"
     exit 0
 fi
 
-# Read PID
 SERVER_PID=$(cat "$PID_FILE")
 
-# Check if process is running
-if ! kill -0 "$SERVER_PID" 2>/dev/null; then
-    echo "Adventure Engine is not running (PID $SERVER_PID not found)"
+# Validate PID is numeric
+if ! [[ "$SERVER_PID" =~ ^[0-9]+$ ]]; then
+    echo "Error: Invalid PID in file: $SERVER_PID" >&2
+    rm -f "$PID_FILE"
+    exit 1
+fi
+
+# Verify this PID is actually a bun/node process (guard against PID reuse)
+if ! ps -p "$SERVER_PID" -o comm= 2>/dev/null | grep -qE '^(bun|node)$'; then
+    echo "Warning: PID $SERVER_PID does not appear to be a bun/node process"
+    echo "Cleaning up stale PID file"
     rm -f "$PID_FILE"
     exit 0
 fi
 
-# Log the stop
+# Log the stop attempt
 {
     echo ""
     echo "=== Adventure Engine Stop ==="
     echo "Timestamp: $(date -Iseconds)"
-    echo "Stopping server (PID: $SERVER_PID)"
-} >> "$LOG_FILE"
+    echo "Stopping server (PID: $SERVER_PID)..."
+} >> "$LOG_FILE" 2>/dev/null || true
 
-# Send SIGTERM for graceful shutdown
+# Check if process is running
+if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "Server (PID: $SERVER_PID) is not running"
+    rm -f "$PID_FILE"
+    echo "Cleaned up stale PID file"
+    echo "Server already stopped" >> "$LOG_FILE" 2>/dev/null || true
+    exit 0
+fi
+
+# Graceful shutdown
 echo "Stopping Adventure Engine (PID: $SERVER_PID)..."
-kill "$SERVER_PID"
+kill "$SERVER_PID" 2>/dev/null || true
 
-# Wait for process to terminate (with timeout)
-MAX_WAIT=10
-for i in $(seq 1 $MAX_WAIT); do
+# Wait for graceful shutdown (up to 5 seconds)
+for i in $(seq 1 5); do
     if ! kill -0 "$SERVER_PID" 2>/dev/null; then
-        echo "Adventure Engine stopped successfully"
-        echo "Server stopped gracefully" >> "$LOG_FILE"
+        echo "Server stopped gracefully"
         rm -f "$PID_FILE"
+        echo "Server stopped gracefully" >> "$LOG_FILE" 2>/dev/null || true
         exit 0
     fi
     sleep 1
 done
 
 # Force kill if still running
-echo "Force killing Adventure Engine..."
+echo "Server did not stop gracefully, force killing..."
 kill -9 "$SERVER_PID" 2>/dev/null || true
-echo "Server force killed" >> "$LOG_FILE"
+sleep 1
+
+if kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "Error: Failed to stop server (PID: $SERVER_PID)" >&2
+    echo "Force kill failed" >> "$LOG_FILE" 2>/dev/null || true
+    exit 1
+fi
+
 rm -f "$PID_FILE"
-echo "Adventure Engine stopped (forced)"
+echo "Server force stopped"
+echo "Server force stopped" >> "$LOG_FILE" 2>/dev/null || true
+


### PR DESCRIPTION
## Summary

- Add proper cleanup mechanism to `launch-world.sh` with signal traps for INT, TERM, EXIT
- Add `SHOULD_CLEANUP_SERVER` flag to control fire-and-forget behavior (cleanup on errors/signals, leave running on successful launch)
- Add PID validation before killing processes (guards against PID reuse vulnerability)
- Improve `stop-world.sh` with process type validation (verifies PID is bun/node before killing)
- Add numeric PID validation to `stop-world.sh`

## Test plan

- [x] Syntax validation with `bash -n` for both scripts
- [x] Backend unit tests pass (298 tests)
- [x] Manual functional tests:
  - stop-world.sh correctly stops running bun processes
  - stop-world.sh detects and cleans up stale PID files (non-bun processes)
  - stop-world.sh rejects invalid PID values

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)