### PR TITLE
fix(backend): resolve world state save inconsistency (#87)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,10 @@ Catalog-first strategy: `ImageCatalogService` searches `/assets/backgrounds` bef
 - `NODE_ENV` (default unset) - Set to "production" for JSON log output, otherwise uses pretty format
 - `MAX_CONNECTIONS` (default 100) - Maximum concurrent WebSocket connections
 
+## Critical Dependencies
+
+**Zod must stay at version 3.x** - The Claude Agent SDK requires Zod 3.24.x. Zod 4.x has breaking API changes that cause MCP tools to fail with `keyValidator._parse is not a function`. All three packages (backend, frontend, shared) are pinned to `zod: 3.24.1`. Do NOT upgrade Zod without verifying SDK compatibility.
+
 ## Code Style
 
 - TypeScript strict mode enabled

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,7 @@
     "pino": "^10.1.0",
     "pino-roll": "^4.0.0",
     "replicate": "^1.4.0",
-    "zod": "^4.1.13"
+    "zod": "3.24.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/backend/src/game-session.ts
+++ b/backend/src/game-session.ts
@@ -318,12 +318,10 @@ export class GameSession {
       options: {
         resume: state.agentSessionId ?? undefined, // Resume conversation if available
         systemPrompt,
-        // Use claude_code preset for Read/Write tools
-        // @ts-expect-error - SDK types don't properly support preset object
-        tools: [{ type: "preset", preset: "claude_code" }],
         // Provide set_theme tool via MCP server (keyed by server name)
         mcpServers: { "adventure-theme": themeMcpServer },
-        allowedTools: ["Read", "Write", "mcp__adventure-theme__set_theme"],
+        // SDK provides tools by default; allowedTools filters to what we need
+        allowedTools: ["Read", "Write", "Glob", "Grep", "mcp__adventure-theme__set_theme"],
         cwd: this.projectDirectory,
         includePartialMessages: true, // Enable token streaming
         permissionMode: "acceptEdits", // Auto-accept file edits within sandbox

--- a/backend/src/gm-prompt.ts
+++ b/backend/src/gm-prompt.ts
@@ -215,64 +215,49 @@ ${worldStateInfo}
 
 ${playerInfo}
 
-CRITICAL - PERSISTENT WORLD TRACKING:
-You MUST use the Write tool to save story elements to files. The chat history is NOT persistent storage.
-Before responding to the player, ALWAYS read existing files to maintain consistency.
-After introducing new elements, ALWAYS update the relevant files.
-
-Required files (create if missing, update when relevant):
-- ./world_state.md - Established facts, rules, history of this world
-- ./locations.md - All discovered/mentioned locations with descriptions
-- ./characters.md - NPCs, their descriptions, relationships, and status
-- ./player.md - Player character details, inventory, abilities, status
-- ./quests.md - Active and completed quests, objectives, progress
-
-When to update files:
-- New location mentioned or visited → Update locations.md
-- New character introduced or changed → Update characters.md
-- Player gains/loses items or abilities → Update player.md
-- Quest started, progressed, or completed → Update quests.md
-- World lore or facts established → Update world_state.md
-
-Use relative paths (e.g., "./locations.md"), never /tmp/.
-
 NARRATIVE GUIDELINES:
-- Respond to player actions with vivid, engaging narrative
-- Maintain consistency with established facts (READ files first!)
+- Respond with vivid, engaging narrative maintaining consistency with files
 - Ask clarifying questions if player intent is ambiguous
 - Keep responses focused and actionable
-- Create an immersive, reactive story experience
 
-THEME CONTROL (IMPORTANT - USE ACTIVELY):
-You have access to set_theme to change the visual atmosphere. The system uses a catalog-first approach:
-1. First searches for cached images matching your mood+genre+region tags
-2. Only generates new images if no cached match exists (using image_prompt)
-3. Falls back to default images if generation fails
+REQUIRED ACTIONS (perform EVERY response - files are your ONLY persistent memory):
 
-REQUIRED PARAMETERS (always provide all three):
+BEFORE RESPONDING - Use the Read tool on existing files to maintain consistency:
+- ./world_state.md, ./locations.md, ./characters.md, ./player.md, ./quests.md
+
+AFTER NARRATIVE - Use the Write tool when state changes:
+- New/changed location → Write to ./locations.md
+- New/changed NPC → Write to ./characters.md
+- Player inventory/abilities → Write to ./player.md
+- Quest progress → Write to ./quests.md
+- World facts established → Write to ./world_state.md
+
+ON FIRST RESPONSE - Create initial files:
+Use the Write tool to create ./world_state.md with: world name, genre, current era, established rules.
+
+DURING NARRATIVE - Set visual theme when mood/location changes:
+Call set_theme(mood, genre, region) for atmosphere transitions.
 - mood: calm | tense | ominous | triumphant | mysterious
 - genre: high-fantasy | low-fantasy | sci-fi | steampunk | horror | modern | historical
 - region: forest | village | city | castle | ruins | mountain | desert | ocean | underground
 
-OPTIONAL PARAMETERS:
-- image_prompt: Scene description for image generation (only used if no cached image matches)
-- force_generate: true to skip cache and generate new image
+ALWAYS perform these actions:
+1. First response: Use Write tool to create ./world_state.md AND call set_theme
+2. Location changes: Use Write tool for ./locations.md AND call set_theme
+3. New NPCs: Use Write tool for ./characters.md
+4. Combat/danger/victory: Call set_theme
+5. Player gains/loses items: Use Write tool for ./player.md
+6. Quest progress: Use Write tool for ./quests.md
 
-ALWAYS call set_theme:
-1. At the START of your very first response to establish the world's atmosphere
-2. When the player enters a new location
-3. When dramatic events occur (combat, danger, victory)
-4. When emotional tone shifts
-
-Example calls:
-- Tavern scene → set_theme(mood="calm", genre="high-fantasy", region="village")
+Theme examples:
+- Tavern → set_theme(mood="calm", genre="high-fantasy", region="village")
 - Dark forest → set_theme(mood="mysterious", genre="high-fantasy", region="forest")
-- Dungeon → set_theme(mood="ominous", genre="high-fantasy", region="underground")
 - Battle → set_theme(mood="tense", genre="high-fantasy", region="forest")
-- Victory → set_theme(mood="triumphant", genre="high-fantasy", region="castle")
 
-Add image_prompt when you want a SPECIFIC generated image:
-- set_theme(mood="calm", genre="high-fantasy", region="village", image_prompt="A cozy medieval tavern, warm firelight, patrons at wooden tables, a bard playing lute")
+File examples:
+- Player finds sword → Write "./player.md" with "## Inventory\n- Iron Sword"
+- Meet innkeeper → Write "./characters.md" with "## Mira\nInnkeeper at Rusty Tankard."
+- Discover village → Write "./locations.md" with "## Thorndale\nSmall farming village."
 
-Be generous with theme changes - they enhance immersion. The player's UI will smoothly transition.`;
+Use relative paths (./file.md), never /tmp/.`;
 }

--- a/backend/tests/unit/zod-version.test.ts
+++ b/backend/tests/unit/zod-version.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Zod Version Compatibility Test
+ *
+ * The Claude Agent SDK requires Zod 3.x. Zod 4.x has breaking API changes
+ * that cause MCP tools to fail with: "keyValidator._parse is not a function"
+ *
+ * This test ensures we don't accidentally upgrade to an incompatible version.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { z } from "zod";
+
+describe("Zod version compatibility", () => {
+  test("Zod must be version 3.x for SDK compatibility", () => {
+    // Zod doesn't export version directly, but we can check for v3-specific behavior
+    // In Zod 3.x, z.string() returns an object with _parse method
+    // In Zod 4.x, this internal API changed, breaking the SDK
+
+    const schema = z.string();
+
+    // This internal method exists in Zod 3.x but was changed in 4.x
+    // The SDK relies on this API for MCP tool validation
+    expect(typeof (schema as unknown as { _parse: unknown })._parse).toBe(
+      "function"
+    );
+  });
+
+  test("Zod schema validation works correctly", () => {
+    // Basic sanity check that Zod is working
+    const schema = z.object({
+      mood: z.enum(["calm", "tense", "ominous"]),
+      genre: z.string(),
+    });
+
+    const valid = schema.safeParse({ mood: "calm", genre: "fantasy" });
+    expect(valid.success).toBe(true);
+
+    const invalid = schema.safeParse({ mood: "invalid", genre: "fantasy" });
+    expect(invalid.success).toBe(false);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
-    "zod": "3"
+    "zod": "3.24.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/shared/package.json
+++ b/shared/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "zod": "3"
+    "zod": "3.24.1"
   }
 }


### PR DESCRIPTION
## Summary

- **Zod version mismatch**: SDK requires Zod 3.x but project had Zod 4.x, causing MCP tools to fail with `keyValidator._parse is not a function`
- **SDK tools not exposed**: Broken `tools: [{ preset: "claude_code" }]` config prevented Read/Write tools from being available
- **Prompt imbalance**: Theme instructions had stronger emphasis than file persistence instructions

## Changes

### Zod Compatibility
- Downgraded all packages (backend, frontend, shared) to `zod@3.24.1`
- Added `tests/unit/zod-version.test.ts` to catch future incompatible upgrades
- Documented constraint in CLAUDE.md "Critical Dependencies" section

### SDK Configuration
- Removed broken preset config; SDK provides Read/Write by default
- Added Glob and Grep to `allowedTools` for file searching

### Prompt Restructure
- Unified persistence and theme into single "REQUIRED ACTIONS" section
- Added explicit first-response directive for initial file creation
- Added concrete file examples matching theme examples

## Test plan

- [x] All backend unit tests pass (300 tests)
- [x] All frontend unit tests pass
- [x] Manual testing: theme changes work
- [x] Manual testing: file saves work (world_state.md created on first response)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)