### PR TITLE
feat(backend): add request ID tracking for log correlation

### DIFF
--- a/.sdd/plans/request-id-tracking.md
+++ b/.sdd/plans/request-id-tracking.md
@@ -1,0 +1,187 @@
+# Request ID Tracking Implementation Plan
+
+## Problem Statement
+
+Cannot correlate log entries across a single request. When a player sends input, logs are generated across multiple functions (message parsing, GameSession processing, SDK calls, image generation, etc.) but there's no common identifier linking them.
+
+## Current State
+
+- **Logger**: Pino with child logger support, rotating file output
+- **Connection tracking**: `connId` (e.g., `conn_1_1734567890123`) per WebSocket connection
+- **Adventure tracking**: `adventureId` per session
+- **Gap**: No request-level correlation - each log entry is independent
+
+## Solution: Request ID Propagation
+
+### Approach: Child Logger Passing
+
+Use Pino's child logger feature to create request-scoped loggers that automatically include `reqId` in all log output.
+
+**Why this approach:**
+1. No function signature changes needed beyond the entry point
+2. Pino child loggers are lightweight (just add context)
+3. Consistent with existing logger.child() usage in error-handler.ts
+4. Works naturally with async operations
+
+### Request ID Format
+
+```
+req_{connId}_{counter}_{timestamp}
+```
+
+Example: `req_conn_1_1734567890123_42_1734567891000`
+
+- Includes connId for connection correlation
+- Counter prevents collisions within same millisecond
+- Timestamp for chronological ordering
+
+### Implementation Steps
+
+#### Step 1: Add Request Logger Factory (logger.ts)
+
+Add helper function to create request-scoped child loggers:
+
+```typescript
+let requestCounter = 0;
+
+export function createRequestLogger(
+  connId: string,
+  adventureId?: string
+): { logger: pino.Logger; reqId: string } {
+  const reqId = `req_${connId}_${++requestCounter}_${Date.now()}`;
+  const childLogger = logger.child({
+    reqId,
+    connId,
+    ...(adventureId && { adventureId }),
+  });
+  return { logger: childLogger, reqId };
+}
+```
+
+#### Step 2: Update GameSession to Accept Request Logger
+
+Modify `processInput` to accept an optional request logger:
+
+```typescript
+async processInput(
+  playerInput: string,
+  requestLogger?: pino.Logger
+): Promise<void> {
+  const log = requestLogger ?? logger;
+  // Use log.info(), log.warn(), etc. throughout
+}
+```
+
+#### Step 3: Update Server WebSocket Handler (server.ts)
+
+In `onMessage`, create request logger and pass to GameSession:
+
+```typescript
+case "player_input": {
+  const { logger: reqLogger, reqId } = createRequestLogger(
+    connId,
+    conn.adventureId
+  );
+  reqLogger.info({ input: msg.input }, "Processing player input");
+
+  await conn.gameSession.processInput(msg.input, reqLogger);
+  break;
+}
+```
+
+#### Step 4: Propagate Logger Through Service Calls
+
+When GameSession calls services (ImageCatalogService, ImageGeneratorService), pass the request logger:
+
+```typescript
+// In handleThemeChange
+const result = await this.imageCatalogService.getBackgroundImage(
+  themeChange.mood,
+  requestLogger
+);
+```
+
+Update service methods to accept optional logger parameter.
+
+### Files to Modify
+
+1. **`backend/src/logger.ts`**
+   - Add `createRequestLogger()` function
+   - Export request counter for testing
+
+2. **`backend/src/server.ts`**
+   - Import `createRequestLogger`
+   - Create request logger in `onMessage` for `player_input`
+   - Pass logger to `GameSession.processInput()`
+
+3. **`backend/src/game-session.ts`**
+   - Update `processInput()` signature to accept optional logger
+   - Use request logger throughout method
+   - Pass logger to service calls and callbacks
+
+4. **`backend/src/services/image-catalog.ts`** (optional)
+   - Accept optional logger in `getBackgroundImage()`
+
+5. **`backend/src/services/image-generator.ts`** (optional)
+   - Accept optional logger in generation methods
+
+### Log Output Example
+
+Before:
+```json
+{"level":30,"time":1734567890123,"msg":"Processing player input"}
+{"level":30,"time":1734567890200,"msg":"SDK message"}
+{"level":30,"time":1734567890300,"msg":"Theme change detected"}
+{"level":30,"time":1734567890400,"msg":"Background image retrieved"}
+```
+
+After:
+```json
+{"level":30,"time":1734567890123,"reqId":"req_conn_1_1_1734567890123","connId":"conn_1_1734567890000","adventureId":"abc-123","msg":"Processing player input"}
+{"level":30,"time":1734567890200,"reqId":"req_conn_1_1_1734567890123","connId":"conn_1_1734567890000","adventureId":"abc-123","msg":"SDK message"}
+{"level":30,"time":1734567890300,"reqId":"req_conn_1_1_1734567890123","connId":"conn_1_1734567890000","adventureId":"abc-123","msg":"Theme change detected"}
+{"level":30,"time":1734567890400,"reqId":"req_conn_1_1_1734567890123","connId":"conn_1_1734567890000","adventureId":"abc-123","msg":"Background image retrieved"}
+```
+
+Now you can grep for `reqId: "req_conn_1_1_1734567890123"` to see all logs from a single request.
+
+### Testing Strategy
+
+1. **Unit tests** for `createRequestLogger()`:
+   - Verify reqId format
+   - Verify counter increments
+   - Verify child logger includes context
+
+2. **Integration test**:
+   - Send player input
+   - Capture logs
+   - Verify all logs for that request share same reqId
+
+### Scope Boundaries
+
+**In scope:**
+- Request ID generation and format
+- Logger propagation for `player_input` messages
+- Core GameSession logging with reqId
+
+**Out of scope (future work):**
+- Request ID for other message types (ping, authenticate, start_adventure)
+- HTTP endpoint request tracking
+- Distributed tracing integration
+- Log aggregation/search infrastructure
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Performance overhead | Pino child loggers are optimized; negligible impact |
+| Breaking existing log parsing | reqId is additive; existing fields unchanged |
+| Memory leaks from logger refs | Request loggers are short-lived; GC handles cleanup |
+
+## Acceptance Criteria
+
+1. All logs from a single `player_input` request share the same `reqId`
+2. `reqId` includes `connId` for connection correlation
+3. Existing log fields (`adventureId`, `connId`) still present
+4. No breaking changes to existing log consumers
+5. Unit tests pass for request logger creation

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,7 +2,7 @@
 // Implements REST endpoints for adventure management and WebSocket upgrade
 
 import { Hono } from "hono";
-import { logger } from "./logger";
+import { logger, createRequestLogger } from "./logger";
 import { createBunWebSocket } from "hono/bun";
 import { serveStatic } from "hono/bun";
 import type { WSContext } from "hono/ws";
@@ -457,8 +457,12 @@ app.get(
               break;
             }
 
+            // Create request-scoped logger for correlation across all logs from this input
+            const { logger: reqLogger } = createRequestLogger(connId, conn.adventureId);
+            reqLogger.info({ inputLength: message.payload.text.length }, "Processing player input");
+
             // Process input through game session (async, don't await)
-            void conn.gameSession.handleInput(message.payload.text);
+            void conn.gameSession.handleInput(message.payload.text, reqLogger);
             break;
           }
 

--- a/backend/tests/unit/request-logger.test.ts
+++ b/backend/tests/unit/request-logger.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for request logger functionality
+ * Tests createRequestLogger for request ID generation and correlation
+ */
+
+import { describe, expect, test, beforeEach } from "bun:test";
+import { createRequestLogger, _resetRequestCounter } from "../../src/logger";
+
+describe("createRequestLogger", () => {
+  beforeEach(() => {
+    // Reset counter between tests for predictable IDs
+    _resetRequestCounter();
+  });
+
+  test("generates unique request IDs", () => {
+    const { reqId: reqId1 } = createRequestLogger("conn_1_123");
+    const { reqId: reqId2 } = createRequestLogger("conn_1_123");
+
+    expect(reqId1).not.toBe(reqId2);
+  });
+
+  test("request ID includes connId", () => {
+    const connId = "conn_42_1734567890123";
+    const { reqId } = createRequestLogger(connId);
+
+    expect(reqId).toContain(connId);
+  });
+
+  test("request ID follows expected format", () => {
+    const connId = "conn_1_123";
+    const { reqId } = createRequestLogger(connId);
+
+    // Format: req_{connId}_{counter}_{timestamp}
+    const pattern = /^req_conn_1_123_\d+_\d+$/;
+    expect(reqId).toMatch(pattern);
+  });
+
+  test("counter increments sequentially", () => {
+    const { reqId: reqId1 } = createRequestLogger("conn_1_123");
+    const { reqId: reqId2 } = createRequestLogger("conn_1_123");
+    const { reqId: reqId3 } = createRequestLogger("conn_1_123");
+
+    // Extract counter values (4th segment after splitting by _)
+    const parts1 = reqId1.split("_");
+    const parts2 = reqId2.split("_");
+    const parts3 = reqId3.split("_");
+
+    // Counter is the 4th segment (index 3) when connId is "conn_1_123"
+    // Full format: req_conn_1_123_counter_timestamp
+    // Parts: [req, conn, 1, 123, counter, timestamp]
+    const counter1 = parseInt(parts1[4], 10);
+    const counter2 = parseInt(parts2[4], 10);
+    const counter3 = parseInt(parts3[4], 10);
+
+    expect(counter2).toBe(counter1 + 1);
+    expect(counter3).toBe(counter2 + 1);
+  });
+
+  test("child logger includes reqId in context", () => {
+    const { logger: reqLogger, reqId } = createRequestLogger("conn_1_123");
+
+    // Access the bindings to verify context is set
+    const bindings = reqLogger.bindings();
+    expect(bindings.reqId).toBe(reqId);
+  });
+
+  test("child logger includes connId in context", () => {
+    const connId = "conn_42_999";
+    const { logger: reqLogger } = createRequestLogger(connId);
+
+    const bindings = reqLogger.bindings();
+    expect(bindings.connId).toBe(connId);
+  });
+
+  test("child logger includes adventureId when provided", () => {
+    const connId = "conn_1_123";
+    const adventureId = "abc-123-def-456";
+    const { logger: reqLogger } = createRequestLogger(connId, adventureId);
+
+    const bindings = reqLogger.bindings();
+    expect(bindings.adventureId).toBe(adventureId);
+  });
+
+  test("child logger omits adventureId when not provided", () => {
+    const { logger: reqLogger } = createRequestLogger("conn_1_123");
+
+    const bindings = reqLogger.bindings();
+    expect(bindings.adventureId).toBeUndefined();
+  });
+
+  test("multiple loggers can be created independently", () => {
+    const { logger: logger1, reqId: reqId1 } = createRequestLogger(
+      "conn_1_100",
+      "adventure-1"
+    );
+    const { logger: logger2, reqId: reqId2 } = createRequestLogger(
+      "conn_2_200",
+      "adventure-2"
+    );
+
+    // Each logger has its own context
+    const bindings1 = logger1.bindings();
+    const bindings2 = logger2.bindings();
+
+    expect(bindings1.connId).toBe("conn_1_100");
+    expect(bindings1.adventureId).toBe("adventure-1");
+    expect(bindings1.reqId).toBe(reqId1);
+
+    expect(bindings2.connId).toBe("conn_2_200");
+    expect(bindings2.adventureId).toBe("adventure-2");
+    expect(bindings2.reqId).toBe(reqId2);
+  });
+
+  test("request ID timestamp is recent", () => {
+    const before = Date.now();
+    const { reqId } = createRequestLogger("conn_1_123");
+    const after = Date.now();
+
+    // Extract timestamp (last segment)
+    const parts = reqId.split("_");
+    const timestamp = parseInt(parts[parts.length - 1], 10);
+
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+  });
+});


### PR DESCRIPTION
## Summary

- Add request ID correlation to trace all logs from a single `player_input` through the entire request lifecycle
- Creates unique `reqId` for each player input that propagates through SDK calls, theme changes, and all related operations
- Enables log correlation for debugging and monitoring

## Changes

- **`backend/src/logger.ts`**: Add `createRequestLogger(connId, adventureId?)` factory function
- **`backend/src/server.ts`**: Create request logger for `player_input` messages, pass to GameSession
- **`backend/src/game-session.ts`**: Propagate request logger through `handleInput()` → `processInput()` → `generateGMResponse()` → `handleSetThemeTool()` → `sendMessage()`
- **`backend/tests/unit/request-logger.test.ts`**: 10 new unit tests for request logger functionality

## Log Output Example

Before:
```json
{"level":30,"msg":"Processing player input"}
{"level":30,"msg":"SDK message"}
{"level":30,"msg":"Theme change detected"}
```

After:
```json
{"level":30,"reqId":"req_conn_1_123_1_1734567890123","connId":"conn_1_123","adventureId":"abc-123","msg":"Processing player input"}
{"level":30,"reqId":"req_conn_1_123_1_1734567890123","connId":"conn_1_123","adventureId":"abc-123","msg":"SDK message"}
{"level":30,"reqId":"req_conn_1_123_1_1734567890123","connId":"conn_1_123","adventureId":"abc-123","msg":"Theme change detected"}
```

## Test plan

- [x] All 310 unit tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] Pre-commit hooks pass
- [ ] Manual verification: Send player input and grep logs by reqId

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)