### PR TITLE
perf(backend): cache image catalog file list to avoid repeated glob scans (#56)

### DIFF
--- a/backend/src/services/background-image.ts
+++ b/backend/src/services/background-image.ts
@@ -178,7 +178,8 @@ export class BackgroundImageService {
         narrativeContext
       );
 
-      // No need to store in catalog - glob will find it by naming convention
+      // Invalidate catalog cache so new image is discoverable
+      this.catalog.invalidateCache();
       this.log(`Generated image saved: ${result.filePath}`);
 
       // Convert path to URL

--- a/backend/tests/unit/background-image.test.ts
+++ b/backend/tests/unit/background-image.test.ts
@@ -21,6 +21,7 @@ class MockImageCatalogService {
     (_mood: ThemeMood, _genre: Genre, _region: Region, _filePath: string, _prompt?: string): void => {}
   );
   getFallback = mock((mood: ThemeMood): string => `./assets/backgrounds/${mood}.jpg`);
+  invalidateCache = mock((): void => {});
   close = mock((): void => {});
 }
 


### PR DESCRIPTION
## Summary

- Add lazy-loaded caching to `ImageCatalogService` to prevent directory scans on every theme change
- Cache file list on first `findImage()` call, filter in memory for subsequent lookups
- Wire up `invalidateCache()` call after successful image generation

Closes #56

## Changes

| File | Change |
|------|--------|
| `image-catalog.ts` | Add `cachedFiles` field, `loadCache()`, `invalidateCache()` methods |
| `background-image.ts` | Call `invalidateCache()` after successful generation |
| `image-catalog.test.ts` | Add 4 cache behavior tests |
| `background-image.test.ts` | Add `invalidateCache` mock |

## Test plan

- [x] All 351 unit tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Cache tests verify: lazy loading, invalidation, per-instance isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)