### PR TITLE
fix(backend): add timeout handling for input queue processing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ Catalog-first strategy: `ImageCatalogService` searches `/assets/backgrounds` bef
 - `LOG_FILE` (default enabled) - Set to "false" to disable rotating file logs in `backend/logs/`
 - `NODE_ENV` (default unset) - Set to "production" for JSON log output, otherwise uses pretty format
 - `MAX_CONNECTIONS` (default 100) - Maximum concurrent WebSocket connections
+- `INPUT_TIMEOUT` (default 60000) - Timeout in milliseconds for input processing (minimum 1000ms)
 
 ## Critical Dependencies
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Terminal-based adventure management integrated into your development workflow:
 | `LOG_FILE` | No | `true` | Set to `false` to disable rotating file logs in `backend/logs/` |
 | `NODE_ENV` | No | — | Set to `production` for JSON log output |
 | `MAX_CONNECTIONS` | No | `100` | Maximum concurrent WebSocket connections |
+| `INPUT_TIMEOUT` | No | `60000` | Timeout in milliseconds for input processing (minimum 1000ms) |
 | `MOCK_SDK` | No | — | Set to `true` to use mock SDK (for testing without Claude Agent SDK) |
 
 \* Required only for image generation. Server runs without it using catalog/fallback images.

--- a/backend/src/error-handler.ts
+++ b/backend/src/error-handler.ts
@@ -7,6 +7,16 @@ import type { ErrorCode } from "./types/protocol";
 import { logger } from "./logger";
 
 /**
+ * Error thrown when input processing exceeds the configured timeout
+ */
+export class ProcessingTimeoutError extends Error {
+  constructor(public readonly timeoutMs: number) {
+    super(`Input processing timed out after ${timeoutMs}ms`);
+    this.name = "ProcessingTimeoutError";
+  }
+}
+
+/**
  * Internal error details for logging
  */
 export interface ErrorDetails {
@@ -126,6 +136,20 @@ export function mapGenericError(error: unknown): ErrorDetails {
     retryable: true,
     userMessage: "Something went wrong. Please try again.",
     technicalDetails: `Unexpected error: ${errorMessage}`,
+    originalError: error,
+  };
+}
+
+/**
+ * Create error details for processing timeout errors
+ */
+export function mapProcessingTimeoutError(error: ProcessingTimeoutError): ErrorDetails {
+  return {
+    code: "PROCESSING_TIMEOUT",
+    message: error.message,
+    retryable: true,
+    userMessage: "The game master is taking too long. Please try again.",
+    technicalDetails: `Input processing timed out after ${error.timeoutMs}ms`,
     originalError: error,
   };
 }

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -14,6 +14,7 @@ export const ErrorCodeSchema = z.enum([
   "RATE_LIMIT",
   "GM_ERROR",
   "STATE_CORRUPTED",
+  "PROCESSING_TIMEOUT",
 ]);
 
 export type ErrorCode = z.infer<typeof ErrorCodeSchema>;


### PR DESCRIPTION
## Summary

- Adds configurable timeout (default 60s) for input processing to prevent indefinite stalls
- Introduces `PROCESSING_TIMEOUT` error code with user-friendly message
- New `INPUT_TIMEOUT` environment variable to configure timeout duration

Closes #57

## Changes

| File | Description |
|------|-------------|
| `shared/protocol.ts` | Added `PROCESSING_TIMEOUT` error code |
| `backend/src/env.ts` | Added `INPUT_TIMEOUT` env var parsing (default 60s, min 1s) |
| `backend/src/error-handler.ts` | Added `ProcessingTimeoutError` class and mapping function |
| `backend/src/game-session.ts` | Added `withTimeout()` utility, wrapped `processInput()` |
| `backend/tests/unit/*.test.ts` | Comprehensive tests for new functionality |
| `CLAUDE.md`, `README.md` | Documented new environment variable |

## Test plan

- [x] All 364 unit tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes
- [ ] Manual test: Set `INPUT_TIMEOUT=5000` and verify timeout error appears after 5s of SDK hang

🤖 Generated with [Claude Code](https://claude.com/claude-code)