### PR TITLE
fix(frontend): add UUID fallback for insecure contexts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,23 @@ import type { ServerMessage, NarrativeEntry } from "../../shared/protocol";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import "./App.css";
 
+// Fallback UUID generator for insecure contexts (non-HTTPS, non-localhost)
+// crypto.randomUUID() is only available in secure contexts
+function generateUUID(): string {
+  if (typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  // Fallback using crypto.getRandomValues() which has broader support
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  // Set version 4 bits
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  // Set variant bits
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 interface AdventureSession {
   adventureId: string;
   sessionToken: string;
@@ -107,7 +124,7 @@ function GameView({
     (text: string) => {
       // Add player input to history immediately
       const playerEntry: NarrativeEntry = {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         timestamp: new Date().toISOString(),
         type: "player_input",
         content: text,


### PR DESCRIPTION
## Summary
- Adds `generateUUID()` helper that falls back to `crypto.getRandomValues()` when `crypto.randomUUID()` is unavailable
- Fixes Firefox error when accessing app via HTTP from LAN IP address (insecure context)

## Root Cause
`crypto.randomUUID()` is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or localhost). When accessing `http://192.168.x.x:3000`, the browser restricts this API.

## Test plan
- [ ] Access app from remote host via HTTP (e.g., `http://192.168.x.x:3000`)
- [ ] Verify send button works and messages appear in narrative log
- [ ] Verify localhost access still works

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)