### PR TITLE
fix(frontend): add theme support for markdown code elements

### DIFF
--- a/frontend/src/components/NarrativeEntry.css
+++ b/frontend/src/components/NarrativeEntry.css
@@ -83,15 +83,16 @@
 }
 
 .narrative-entry__content blockquote {
-  border-left: 3px solid #ccc;
+  border-left: 3px solid var(--color-border);
   margin: 0.5em 0;
   padding-left: 1em;
-  color: #555;
+  color: var(--color-text-secondary);
   font-style: italic;
 }
 
 .narrative-entry__content code {
-  background-color: #e8e8e8;
+  background-color: var(--color-code-bg);
+  color: var(--color-code-text);
   padding: 0.1em 0.3em;
   border-radius: 3px;
   font-family: monospace;
@@ -99,8 +100,8 @@
 }
 
 .narrative-entry__content pre {
-  background-color: #2d2d2d;
-  color: #f8f8f2;
+  background-color: var(--color-pre-bg);
+  color: var(--color-pre-text);
   padding: 1em;
   border-radius: var(--radius-sm);
   overflow-x: auto;

--- a/frontend/src/themes.json
+++ b/frontend/src/themes.json
@@ -17,7 +17,11 @@
         "gmBg": "#f5f5f5",
         "gmBorder": "#757575",
         "error": "#721c24",
-        "errorBg": "#f8d7da"
+        "errorBg": "#f8d7da",
+        "codeBg": "#e3f2fd",
+        "codeText": "#1565c0",
+        "preBg": "#263238",
+        "preText": "#eceff1"
       },
       "fonts": {
         "family": "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif"
@@ -45,7 +49,11 @@
         "gmBg": "#ffe0b2",
         "gmBorder": "#b33a00",
         "error": "#8b0000",
-        "errorBg": "#ffccbc"
+        "errorBg": "#ffccbc",
+        "codeBg": "#fff3e0",
+        "codeText": "#bf360c",
+        "preBg": "#3e2723",
+        "preText": "#efebe9"
       },
       "fonts": {
         "family": "'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif"
@@ -73,7 +81,11 @@
         "gmBg": "#1f1520",
         "gmBorder": "#9c27b0",
         "error": "#ff6b6b",
-        "errorBg": "#4a1a1a"
+        "errorBg": "#4a1a1a",
+        "codeBg": "#4a148c",
+        "codeText": "#e1bee7",
+        "preBg": "#12001a",
+        "preText": "#ce93d8"
       },
       "fonts": {
         "family": "'Garamond', 'Georgia', serif"
@@ -101,7 +113,11 @@
         "gmBg": "#fffef7",
         "gmBorder": "#cc7000",
         "error": "#b71c1c",
-        "errorBg": "#ffebee"
+        "errorBg": "#ffebee",
+        "codeBg": "#fff8e1",
+        "codeText": "#8b6914",
+        "preBg": "#3e2723",
+        "preText": "#fff8e1"
       },
       "fonts": {
         "family": "'Palatino Linotype', 'Book Antiqua', Palatino, serif"
@@ -129,7 +145,11 @@
         "gmBg": "#1a1f2e",
         "gmBorder": "#9c27b0",
         "error": "#ff5252",
-        "errorBg": "#3d1a1a"
+        "errorBg": "#3d1a1a",
+        "codeBg": "#006064",
+        "codeText": "#e0f7fa",
+        "preBg": "#000a12",
+        "preText": "#80deea"
       },
       "fonts": {
         "family": "'Courier New', Courier, monospace"

--- a/frontend/src/types/theme.ts
+++ b/frontend/src/types/theme.ts
@@ -38,6 +38,14 @@ export interface ThemeColors {
   error: string;
   /** Error background color */
   errorBg: string;
+  /** Inline code background */
+  codeBg: string;
+  /** Inline code text */
+  codeText: string;
+  /** Code block background */
+  preBg: string;
+  /** Code block text */
+  preText: string;
 }
 
 /**
@@ -102,4 +110,8 @@ export const CSS_VARIABLE_MAP: Record<keyof ThemeColors, string> = {
   gmBorder: "--color-gm-border",
   error: "--color-error",
   errorBg: "--color-error-bg",
+  codeBg: "--color-code-bg",
+  codeText: "--color-code-text",
+  preBg: "--color-pre-bg",
+  preText: "--color-pre-text",
 };


### PR DESCRIPTION
## Summary

- Add CSS variables for inline code and code block styling across all themes
- Fix unreadable code text on dark themes (previously light grey on light grey)
- Also fix blockquote styling to use theme variables

Closes #111

## Changes

| File | Change |
|------|--------|
| `types/theme.ts` | Add `codeBg`, `codeText`, `preBg`, `preText` to ThemeColors interface |
| `themes.json` | Define appropriate colors for all 5 theme moods |
| `NarrativeEntry.css` | Replace hardcoded colors with CSS variables |

## Test plan

- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] All 95 unit tests pass
- [ ] Manual verification: Check code styling in all theme moods (calm, tense, ominous, triumphant, mysterious)

🤖 Generated with [Claude Code](https://claude.com/claude-code)