### PR TITLE
fix(backend): use relative URLs for background images

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -98,7 +98,7 @@ const backgroundImageService = new BackgroundImageService(
   imageCatalogService,
   imageGeneratorService,
   {
-    baseUrl: "http://localhost:3000/backgrounds",
+    baseUrl: "/backgrounds",
     verbose: true,
   }
 );

--- a/backend/src/services/background-image.ts
+++ b/backend/src/services/background-image.ts
@@ -31,7 +31,7 @@ import { logger } from "../logger";
  * Configuration for BackgroundImageService
  */
 interface BackgroundImageConfig {
-  /** Base URL for serving static background images (e.g., "http://localhost:3000/backgrounds") */
+  /** Base URL for serving static background images (e.g., "/backgrounds") */
   baseUrl: string;
   /** Enable verbose logging for debugging */
   verbose?: boolean;
@@ -73,7 +73,7 @@ export interface BackgroundImageResult {
  * const orchestrator = new BackgroundImageService(
  *   catalogService,
  *   generatorService,
- *   { baseUrl: "http://localhost:3000/backgrounds" }
+ *   { baseUrl: "/backgrounds" }
  * );
  *
  * const result = await orchestrator.getBackgroundImage(

--- a/backend/tests/integration/mcp-tool-use.test.ts
+++ b/backend/tests/integration/mcp-tool-use.test.ts
@@ -198,7 +198,7 @@ describe("MCP Tool Use via Mock SDK", () => {
       const mockBgService = {
         getBackgroundImage: mock(() =>
           Promise.resolve({
-            url: "http://localhost:3000/backgrounds/ominous-forest.jpg",
+            url: "/backgrounds/ominous-forest.jpg",
             source: "catalog" as const,
           })
         ),
@@ -216,7 +216,7 @@ describe("MCP Tool Use via Mock SDK", () => {
       const themeMsg = themeMessages[0];
       if (themeMsg.type === "theme_change") {
         expect(themeMsg.payload.backgroundUrl).toBe(
-          "http://localhost:3000/backgrounds/ominous-forest.jpg"
+          "/backgrounds/ominous-forest.jpg"
         );
       }
 

--- a/backend/tests/unit/background-image.test.ts
+++ b/backend/tests/unit/background-image.test.ts
@@ -49,7 +49,7 @@ describe("BackgroundImageService", () => {
   let generatorService: MockImageGeneratorService;
   let orchestrator: BackgroundImageService;
 
-  const BASE_URL = "http://localhost:3000/backgrounds";
+  const BASE_URL = "/backgrounds";
 
   beforeEach(() => {
     catalogService = new MockImageCatalogService();
@@ -70,7 +70,7 @@ describe("BackgroundImageService", () => {
       const withSlash = new BackgroundImageService(
         catalogService as unknown as ImageCatalogService,
         generatorService as unknown as ImageGeneratorService,
-        { baseUrl: "http://localhost:3000/backgrounds/" }
+        { baseUrl: "/backgrounds/" }
       );
       expect(withSlash).toBeDefined();
     });


### PR DESCRIPTION
## Summary
- Changed `baseUrl` from `"http://localhost:3000/backgrounds"` to `"/backgrounds"` so background image URLs work when accessed from remote hosts
- Updated JSDoc examples in `BackgroundImageService` to reflect relative path pattern
- Updated unit and integration tests to use relative URLs

## Root Cause
The `BackgroundImageService` was configured with a hardcoded localhost URL. When the frontend received a `theme_change` message with `backgroundUrl: "http://localhost:3000/backgrounds/image.jpg"`, it would fail to load the image when accessed from any host other than localhost.

## Fix
Using a relative path (`/backgrounds/image.jpg`) allows the browser to resolve the URL relative to its current origin, working correctly regardless of the host.

## Test plan
- [x] All 460 backend tests pass
- [x] Typecheck passes
- [x] Lint passes
- [ ] Manual test: access from remote host and verify background images load

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)