### PR TITLE
feat(frontend): add markdown table support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "zod": "3.24.1"
   },
   "devDependencies": {

--- a/frontend/src/components/NarrativeEntry.css
+++ b/frontend/src/components/NarrativeEntry.css
@@ -123,3 +123,27 @@
 .narrative-entry__content h1 { font-size: 1.3em; }
 .narrative-entry__content h2 { font-size: 1.15em; }
 .narrative-entry__content h3 { font-size: 1.05em; }
+
+/* Table styles */
+.narrative-entry__content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.75em 0;
+  font-size: 0.95em;
+}
+
+.narrative-entry__content th,
+.narrative-entry__content td {
+  border: 1px solid var(--color-border);
+  padding: 0.5em 0.75em;
+  text-align: left;
+}
+
+.narrative-entry__content th {
+  background-color: color-mix(in srgb, var(--color-border) 30%, transparent);
+  font-weight: 600;
+}
+
+.narrative-entry__content tr:nth-child(even) {
+  background-color: color-mix(in srgb, var(--color-border) 10%, transparent);
+}

--- a/frontend/src/components/NarrativeEntry.tsx
+++ b/frontend/src/components/NarrativeEntry.tsx
@@ -1,4 +1,5 @@
 import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import type { NarrativeEntry as NarrativeEntryType } from "../types/protocol";
 import "./NarrativeEntry.css";
 
@@ -30,7 +31,7 @@ export function NarrativeEntry({
         {isPlayerInput ? (
           <span className="narrative-entry__content--player">{displayContent}</span>
         ) : (
-          <Markdown>{displayContent ?? ""}</Markdown>
+          <Markdown remarkPlugins={[remarkGfm]}>{displayContent ?? ""}</Markdown>
         )}
         {isStreaming && <span className="streaming-cursor" />}
       </div>

--- a/frontend/tests/unit/NarrativeEntry.test.tsx
+++ b/frontend/tests/unit/NarrativeEntry.test.tsx
@@ -1,0 +1,138 @@
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NarrativeEntry } from "../../src/components/NarrativeEntry";
+import type { NarrativeEntry as NarrativeEntryType } from "../../src/types/protocol";
+
+describe("NarrativeEntry", () => {
+  describe("markdown rendering", () => {
+    test("renders markdown tables as HTML tables", () => {
+      const entry: NarrativeEntryType = {
+        id: "entry-1",
+        timestamp: new Date().toISOString(),
+        type: "gm_response",
+        content: `| Stat | Value |
+| --- | --- |
+| Strength | 16 |
+| Dexterity | 14 |`,
+      };
+
+      render(<NarrativeEntry entry={entry} />);
+
+      const table = document.querySelector("table");
+      expect(table).toBeInTheDocument();
+
+      expect(screen.getByText("Stat")).toBeInTheDocument();
+      expect(screen.getByText("Strength")).toBeInTheDocument();
+      expect(screen.getByText("16")).toBeInTheDocument();
+    });
+
+    test("renders table headers with th elements", () => {
+      const entry: NarrativeEntryType = {
+        id: "entry-1",
+        timestamp: new Date().toISOString(),
+        type: "gm_response",
+        content: `| Name | HP |
+| --- | --- |
+| Goblin | 7 |`,
+      };
+
+      render(<NarrativeEntry entry={entry} />);
+
+      const headers = document.querySelectorAll("th");
+      expect(headers).toHaveLength(2);
+      expect(headers[0]).toHaveTextContent("Name");
+      expect(headers[1]).toHaveTextContent("HP");
+    });
+
+    test("renders table data with td elements", () => {
+      const entry: NarrativeEntryType = {
+        id: "entry-1",
+        timestamp: new Date().toISOString(),
+        type: "gm_response",
+        content: `| Item | Qty |
+| --- | --- |
+| Potion | 3 |
+| Sword | 1 |`,
+      };
+
+      render(<NarrativeEntry entry={entry} />);
+
+      const cells = document.querySelectorAll("td");
+      expect(cells).toHaveLength(4);
+      expect(cells[0]).toHaveTextContent("Potion");
+      expect(cells[1]).toHaveTextContent("3");
+    });
+
+    test("renders mixed content with tables and text", () => {
+      const entry: NarrativeEntryType = {
+        id: "entry-1",
+        timestamp: new Date().toISOString(),
+        type: "gm_response",
+        content: `Your character sheet:
+
+| Attribute | Score |
+| --- | --- |
+| STR | 18 |
+
+You're ready for adventure!`,
+      };
+
+      render(<NarrativeEntry entry={entry} />);
+
+      expect(screen.getByText(/Your character sheet/)).toBeInTheDocument();
+      expect(document.querySelector("table")).toBeInTheDocument();
+      expect(screen.getByText(/ready for adventure/)).toBeInTheDocument();
+    });
+  });
+
+  describe("player input", () => {
+    test("does not apply markdown to player input", () => {
+      const entry: NarrativeEntryType = {
+        id: "entry-1",
+        timestamp: new Date().toISOString(),
+        type: "player_input",
+        content: "| this | is | not | a | table |",
+      };
+
+      render(<NarrativeEntry entry={entry} />);
+
+      expect(document.querySelector("table")).not.toBeInTheDocument();
+      expect(screen.getByText("| this | is | not | a | table |")).toBeInTheDocument();
+    });
+  });
+
+  describe("streaming", () => {
+    test("renders streaming content with markdown", () => {
+      const entry: NarrativeEntryType = {
+        id: "entry-1",
+        timestamp: new Date().toISOString(),
+        type: "gm_response",
+        content: "",
+      };
+
+      render(
+        <NarrativeEntry
+          entry={entry}
+          isStreaming
+          streamingText="**Bold** and *italic*"
+        />
+      );
+
+      expect(document.querySelector("strong")).toBeInTheDocument();
+      expect(document.querySelector("em")).toBeInTheDocument();
+    });
+
+    test("shows streaming cursor when streaming", () => {
+      const entry: NarrativeEntryType = {
+        id: "entry-1",
+        timestamp: new Date().toISOString(),
+        type: "gm_response",
+        content: "",
+      };
+
+      render(<NarrativeEntry entry={entry} isStreaming streamingText="Loading..." />);
+
+      expect(document.querySelector(".streaming-cursor")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `remark-gfm` plugin to enable GitHub Flavored Markdown table rendering
- Add CSS styles for tables (borders, header highlighting, alternating row colors)
- Add unit tests for table rendering in NarrativeEntry component

Closes #112

## Test plan
- [x] Verify tables render as HTML `<table>` elements instead of raw `|` characters
- [x] Verify table headers have background highlighting
- [x] Verify alternating row colors for readability
- [x] Verify player input is not affected (no markdown processing)
- [x] All 102 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)