### PR TITLE
feat: implement automatic history compaction

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -628,12 +628,13 @@ async function validateAndLoadAdventure(
     }
   }
 
-  // Send adventure loaded confirmation with history
+  // Send adventure loaded confirmation with history and optional summary
   const loadedMsg: ServerMessage = {
     type: "adventure_loaded",
     payload: {
       adventureId: result.state.id,
       history: result.history.entries,
+      summary: result.history.summary ?? null,
     },
   };
 

--- a/backend/src/services/history-compactor.ts
+++ b/backend/src/services/history-compactor.ts
@@ -1,0 +1,415 @@
+/**
+ * History Compactor Service
+ *
+ * Implements history compaction for adventure narratives:
+ * 1. Archives older entries to dated markdown files
+ * 2. Generates AI summaries of archived content
+ * 3. Retains recent entries for immediate context
+ *
+ * Compaction is triggered when history exceeds a character threshold,
+ * keeping gameplay responsive while preserving narrative continuity.
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { NarrativeEntry, HistorySummary, NarrativeHistory } from "../../../shared/protocol";
+import type { CompactionConfig, CompactionResult } from "../types/state";
+import { logger } from "../logger";
+import { env } from "../env";
+
+// Dynamic import for SDK to support mock mode
+let query: typeof import("@anthropic-ai/claude-agent-sdk").query | undefined;
+
+/**
+ * Initialize the SDK query function.
+ * Uses real SDK in production, skips in mock mode.
+ */
+async function initializeQuery(): Promise<void> {
+  if (env.mockSdk) {
+    return; // Mock mode uses inline mock function
+  }
+  if (!query) {
+    const sdk = await import("@anthropic-ai/claude-agent-sdk");
+    query = sdk.query;
+  }
+}
+
+/**
+ * Summarization prompt for Claude.
+ * Focuses on narrative-relevant information for returning players.
+ */
+const SUMMARIZATION_PROMPT = `You are summarizing a narrative adventure history for context continuity.
+
+The history contains player inputs and Game Master (GM) responses from an interactive text adventure.
+
+SUMMARIZATION GUIDELINES:
+1. Preserve key PLOT POINTS:
+   - Major story events and turning points
+   - Important discoveries or revelations
+   - Quest progress and objectives
+
+2. Track CHARACTER DEVELOPMENTS:
+   - Player character name and key traits established
+   - NPCs introduced and their significance
+   - Relationships formed or changed
+
+3. Note WORLD STATE changes:
+   - Locations visited and their significance
+   - Items acquired or lost
+   - Important lore or facts established
+
+4. Keep the NARRATIVE TONE:
+   - Match the adventure's genre and style
+   - Preserve emotional high points
+   - Note any running jokes or callbacks
+
+FORMAT:
+Write a cohesive narrative summary in 2nd person ("You"), as if recapping for a returning player.
+Target length: 200-400 words.
+Start with "Previously in your adventure..." or similar.
+
+Do NOT include:
+- Mundane movements or routine actions
+- Exact dialogue unless particularly significant
+- Technical details or dice rolls
+- Meta-commentary about the game itself
+
+HISTORY TO SUMMARIZE:
+`;
+
+/**
+ * Service for compacting adventure history.
+ *
+ * When history grows beyond the configured threshold, this service:
+ * 1. Archives older entries to markdown files
+ * 2. Generates an AI summary of the archived content
+ * 3. Retains recent entries for immediate context
+ */
+export class HistoryCompactor {
+  private adventureDir: string;
+  private config: CompactionConfig;
+  private log: ReturnType<typeof logger.child>;
+  private compactionInProgress = false;
+
+  /**
+   * Create a new HistoryCompactor instance.
+   *
+   * @param adventureDir - Directory containing the adventure state files
+   * @param config - Compaction configuration
+   */
+  constructor(adventureDir: string, config: CompactionConfig) {
+    this.adventureDir = adventureDir;
+    this.config = config;
+    this.log = logger.child({ component: "HistoryCompactor" });
+  }
+
+  /**
+   * Check if history should be compacted based on character count.
+   *
+   * @param history - Current narrative history
+   * @returns true if compaction should occur
+   */
+  shouldCompact(history: NarrativeHistory): boolean {
+    const totalChars = history.entries.reduce(
+      (sum, entry) => sum + entry.content.length,
+      0
+    );
+    return totalChars >= env.compactionCharThreshold;
+  }
+
+  /**
+   * Calculate total character count of history entries.
+   *
+   * @param history - Narrative history
+   * @returns Total characters across all entries
+   */
+  getHistorySize(history: NarrativeHistory): number {
+    return history.entries.reduce(
+      (sum, entry) => sum + entry.content.length,
+      0
+    );
+  }
+
+  /**
+   * Perform compaction on the history.
+   * Archives older entries, generates summary, and returns retained entries.
+   *
+   * @param history - Current narrative history
+   * @returns Compaction result with archive path, summary, and retained entries
+   */
+  async compact(history: NarrativeHistory): Promise<CompactionResult> {
+    // Prevent concurrent compaction
+    if (this.compactionInProgress) {
+      this.log.warn("Compaction already in progress, skipping");
+      return {
+        success: false,
+        error: "Compaction already in progress",
+      };
+    }
+
+    this.compactionInProgress = true;
+
+    try {
+      const entryCount = history.entries.length;
+      const retainCount = Math.min(this.config.retainedCount, entryCount);
+
+      // If we don't have enough entries to compact, skip
+      if (entryCount <= retainCount) {
+        this.log.debug({ entryCount, retainCount }, "Not enough entries to compact");
+        return {
+          success: false,
+          error: "Not enough entries to compact",
+        };
+      }
+
+      const archiveCount = entryCount - retainCount;
+      const entriesToArchive = history.entries.slice(0, archiveCount);
+      const retainedEntries = history.entries.slice(archiveCount);
+
+      this.log.info(
+        { archiveCount, retainCount, totalChars: this.getHistorySize(history) },
+        "Starting history compaction"
+      );
+
+      // Step 1: Archive entries to markdown
+      let archivePath: string;
+      try {
+        archivePath = await this.archiveEntries(entriesToArchive);
+        this.log.info({ archivePath }, "Entries archived successfully");
+      } catch (error) {
+        this.log.error({ error }, "Failed to archive entries");
+        return {
+          success: false,
+          error: `Archive failed: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+
+      // Step 2: Generate summary
+      let summary: HistorySummary | null = null;
+      try {
+        const summaryText = await this.generateSummary(entriesToArchive);
+        const dateRange = this.getDateRange(entriesToArchive);
+
+        summary = {
+          generatedAt: new Date().toISOString(),
+          model: this.config.model,
+          entriesArchived: archiveCount,
+          dateRange,
+          text: summaryText,
+        };
+        this.log.info({ entriesArchived: archiveCount }, "Summary generated successfully");
+      } catch (error) {
+        // Summarization failure is non-fatal - we still have the archive
+        this.log.warn({ error }, "Failed to generate summary, proceeding without");
+        summary = null;
+      }
+
+      return {
+        success: true,
+        archivePath,
+        entriesArchived: archiveCount,
+        retainedEntries,
+        summary,
+      };
+    } finally {
+      this.compactionInProgress = false;
+    }
+  }
+
+  /**
+   * Archive entries to a markdown file with YAML frontmatter.
+   *
+   * @param entries - Entries to archive
+   * @returns Path to the created archive file
+   */
+  private async archiveEntries(entries: NarrativeEntry[]): Promise<string> {
+    const historyDir = join(this.adventureDir, "history");
+    await mkdir(historyDir, { recursive: true, mode: 0o700 });
+
+    const now = new Date();
+    const filename = this.formatArchiveFilename(now);
+    const archivePath = join(historyDir, filename);
+
+    const dateRange = this.getDateRange(entries);
+    const content = this.formatArchiveContent(entries, dateRange, now);
+
+    await writeFile(archivePath, content, { encoding: "utf-8", mode: 0o600 });
+
+    return archivePath;
+  }
+
+  /**
+   * Check if we should use mock mode.
+   * Config override takes precedence over environment setting.
+   */
+  private get useMockSdk(): boolean {
+    return this.config.mockSdk ?? env.mockSdk;
+  }
+
+  /**
+   * Generate a summary of the archived entries using Claude.
+   *
+   * @param entries - Entries to summarize
+   * @returns Summary text
+   */
+  private async generateSummary(entries: NarrativeEntry[]): Promise<string> {
+    const historyText = this.formatEntriesForSummary(entries);
+    const prompt = SUMMARIZATION_PROMPT + historyText;
+
+    if (this.useMockSdk) {
+      // Mock mode: return a simple summary
+      return this.mockSummarize(entries);
+    }
+
+    // Initialize SDK if needed
+    await initializeQuery();
+
+    if (!query) {
+      throw new Error("SDK query not available");
+    }
+
+    // Query Claude for summary
+    const sdkQuery = query({
+      prompt,
+      options: {
+        systemPrompt: "You are a narrative summarizer for interactive adventures.",
+        model: this.config.model,
+        maxTurns: 1,
+        allowedTools: [], // No tools needed for summarization
+      },
+    });
+
+    let summaryText = "";
+
+    for await (const message of sdkQuery) {
+      if (message.type === "stream_event") {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const event = message.event;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        if (event?.type === "content_block_delta" && event.delta?.type === "text_delta") {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          summaryText += event.delta.text as string;
+        }
+      }
+
+      if (message.type === "assistant") {
+        if (message.error) {
+          throw new Error(`SDK error: ${message.error}`);
+        }
+        // Fallback to complete message if streaming didn't capture
+        if (!summaryText) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          const content = message.message?.content;
+          if (Array.isArray(content)) {
+            for (const block of content) {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              if (block.type === "text") {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                summaryText = block.text as string;
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (!summaryText) {
+      throw new Error("No summary generated");
+    }
+
+    return summaryText.trim();
+  }
+
+  /**
+   * Mock summarization for testing without API calls.
+   */
+  private mockSummarize(entries: NarrativeEntry[]): string {
+    const playerInputs = entries.filter(e => e.type === "player_input");
+    const gmResponses = entries.filter(e => e.type === "gm_response");
+
+    return `Previously in your adventure...
+
+You embarked on a journey through this interactive narrative. Over the course of ${playerInputs.length} actions and ${gmResponses.length} Game Master responses, your story unfolded.
+
+[This is a mock summary generated for testing. In production, Claude will generate a detailed narrative recap of your adventure's key events, character developments, and world state changes.]
+
+The adventure continues from where you left off.`;
+  }
+
+  /**
+   * Format entries for summarization prompt.
+   */
+  private formatEntriesForSummary(entries: NarrativeEntry[]): string {
+    return entries
+      .map((entry) => {
+        const type = entry.type === "player_input" ? "Player" : "GM";
+        const date = new Date(entry.timestamp).toLocaleString();
+        return `[${date}] ${type}: ${entry.content}`;
+      })
+      .join("\n\n");
+  }
+
+  /**
+   * Format archive filename with timestamp.
+   */
+  private formatArchiveFilename(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    const seconds = String(date.getSeconds()).padStart(2, "0");
+
+    return `${year}-${month}-${day}-${hours}${minutes}${seconds}.md`;
+  }
+
+  /**
+   * Format archive content with YAML frontmatter.
+   */
+  private formatArchiveContent(
+    entries: NarrativeEntry[],
+    dateRange: { from: string; to: string },
+    archivedAt: Date
+  ): string {
+    const frontmatter = [
+      "---",
+      `archived_at: "${archivedAt.toISOString()}"`,
+      "date_range:",
+      `  from: "${dateRange.from}"`,
+      `  to: "${dateRange.to}"`,
+      `entry_count: ${entries.length}`,
+      "---",
+      "",
+    ].join("\n");
+
+    const header = "# Archived Adventure History\n\n## Entries\n\n";
+
+    const entryContent = entries
+      .map((entry) => {
+        const date = new Date(entry.timestamp);
+        const dateStr = date.toISOString().replace("T", " ").slice(0, 19);
+        const type = entry.type === "player_input" ? "Player Input" : "GM Response";
+
+        return `### ${dateStr} - ${type}\n\n${entry.type === "player_input" ? "> " : ""}${entry.content}\n`;
+      })
+      .join("\n");
+
+    return frontmatter + header + entryContent;
+  }
+
+  /**
+   * Get date range from entries.
+   */
+  private getDateRange(entries: NarrativeEntry[]): { from: string; to: string } {
+    if (entries.length === 0) {
+      const now = new Date().toISOString();
+      return { from: now, to: now };
+    }
+
+    return {
+      from: entries[0].timestamp,
+      to: entries[entries.length - 1].timestamp,
+    };
+  }
+}

--- a/backend/src/types/state.ts
+++ b/backend/src/types/state.ts
@@ -11,10 +11,12 @@ import type {
   CombatState,
   SystemDefinition,
   PlayerCharacter,
+  HistorySummary,
+  NarrativeHistory,
 } from "../../../shared/protocol";
 
 // Re-export types needed by other modules
-export type { SystemDefinition } from "../../../shared/protocol";
+export type { SystemDefinition, HistorySummary, NarrativeHistory } from "../../../shared/protocol";
 
 /**
  * Adventure state stored in state.json
@@ -46,12 +48,36 @@ export interface AdventureState {
   systemDefinition?: SystemDefinition | null;
 }
 
+// NarrativeHistory is now imported from shared/protocol.ts
+// It includes optional summary field for compaction support
+
 /**
- * Narrative history stored in history.json
- * Append-only log of player inputs and GM responses
+ * Configuration for history compaction
  */
-export interface NarrativeHistory {
-  entries: NarrativeEntry[];
+export interface CompactionConfig {
+  /** Number of entries to retain after compaction */
+  retainedCount: number;
+  /** Model to use for summarization */
+  model: string;
+  /** Override for mock SDK mode (defaults to env.mockSdk) */
+  mockSdk?: boolean;
+}
+
+/**
+ * Result of a compaction operation
+ */
+export interface CompactionResult {
+  success: boolean;
+  /** Path to the archive file (if successful) */
+  archivePath?: string;
+  /** Number of entries that were archived */
+  entriesArchived?: number;
+  /** Entries retained after compaction */
+  retainedEntries?: NarrativeEntry[];
+  /** Generated summary (null if summarization failed) */
+  summary?: HistorySummary | null;
+  /** Error message (if failed) */
+  error?: string;
 }
 
 /**

--- a/backend/tests/unit/env.test.ts
+++ b/backend/tests/unit/env.test.ts
@@ -311,6 +311,9 @@ describe("validateEnvironment", () => {
       staticRoot: "/var/www/static",
       mockSdk: true,
       replicateApiToken: "r8_abc123",
+      compactionCharThreshold: 100000,
+      retainedEntryCount: 20,
+      compactionSummaryModel: "claude-haiku-3",
     });
   });
 

--- a/backend/tests/unit/history-compactor.test.ts
+++ b/backend/tests/unit/history-compactor.test.ts
@@ -1,0 +1,226 @@
+// History Compactor Tests
+// Unit tests for history compaction, archiving, and summarization
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdir, rm, readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { HistoryCompactor } from "../../src/services/history-compactor";
+import type { NarrativeEntry, NarrativeHistory } from "../../../shared/protocol";
+
+const TEST_ADVENTURE_DIR = "./test-adventure-compaction";
+
+// Helper to create test entries
+function createTestEntry(
+  index: number,
+  type: "player_input" | "gm_response",
+  contentLength = 100
+): NarrativeEntry {
+  const content = `${"x".repeat(contentLength)} (entry ${index})`;
+  return {
+    id: `entry-${index}`,
+    timestamp: new Date(Date.now() - (100 - index) * 60000).toISOString(), // Stagger timestamps
+    type,
+    content,
+  };
+}
+
+// Helper to create a history with n entries
+function createTestHistory(entryCount: number, contentLength = 100): NarrativeHistory {
+  const entries: NarrativeEntry[] = [];
+  for (let i = 0; i < entryCount; i++) {
+    entries.push(
+      createTestEntry(i, i % 2 === 0 ? "player_input" : "gm_response", contentLength)
+    );
+  }
+  return { entries };
+}
+
+describe("HistoryCompactor", () => {
+  let compactor: HistoryCompactor;
+
+  beforeEach(async () => {
+    // Clean test directory before each test
+    await rm(TEST_ADVENTURE_DIR, { recursive: true, force: true });
+    await mkdir(TEST_ADVENTURE_DIR, { recursive: true });
+
+    compactor = new HistoryCompactor(TEST_ADVENTURE_DIR, {
+      retainedCount: 20,
+      model: "claude-haiku-3",
+      mockSdk: true,
+    });
+  });
+
+  afterEach(async () => {
+    // Clean up after each test
+    await rm(TEST_ADVENTURE_DIR, { recursive: true, force: true });
+  });
+
+  describe("shouldCompact()", () => {
+    test("returns false when history is below threshold", () => {
+      // Create history with 10 entries of 100 chars each = 1000 chars
+      const history = createTestHistory(10, 100);
+      expect(compactor.shouldCompact(history)).toBe(false);
+    });
+
+    test("returns true when history exceeds threshold", () => {
+      // Create history that exceeds 100,000 chars
+      // 100 entries * 1100 chars each = 110,000 chars
+      const history = createTestHistory(100, 1100);
+      expect(compactor.shouldCompact(history)).toBe(true);
+    });
+
+    test("returns false for empty history", () => {
+      const history: NarrativeHistory = { entries: [] };
+      expect(compactor.shouldCompact(history)).toBe(false);
+    });
+  });
+
+  describe("getHistorySize()", () => {
+    test("returns 0 for empty history", () => {
+      const history: NarrativeHistory = { entries: [] };
+      expect(compactor.getHistorySize(history)).toBe(0);
+    });
+
+    test("calculates total characters correctly", () => {
+      const history = createTestHistory(5, 200);
+      // Each entry has ~200 chars + " (entry X)" suffix
+      const expectedMin = 5 * 200;
+      const size = compactor.getHistorySize(history);
+      expect(size).toBeGreaterThanOrEqual(expectedMin);
+    });
+  });
+
+  describe("compact()", () => {
+    test("returns error when not enough entries to compact", async () => {
+      const history = createTestHistory(10);
+      const result = await compactor.compact(history);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Not enough entries");
+    });
+
+    test("archives older entries and retains recent ones", async () => {
+      // Create history with 30 entries, should archive 10 and retain 20
+      const history = createTestHistory(30);
+      const result = await compactor.compact(history);
+
+      expect(result.success).toBe(true);
+      expect(result.entriesArchived).toBe(10);
+      expect(result.retainedEntries).toHaveLength(20);
+      expect(result.archivePath).toBeDefined();
+
+      // Verify retained entries are the most recent
+      expect(result.retainedEntries![0].id).toBe("entry-10");
+      expect(result.retainedEntries![19].id).toBe("entry-29");
+    });
+
+    test("creates archive file with correct format", async () => {
+      const history = createTestHistory(30);
+      const result = await compactor.compact(history);
+
+      expect(result.success).toBe(true);
+      expect(result.archivePath).toBeDefined();
+
+      // Read archive file
+      const archiveContent = await readFile(result.archivePath!, "utf-8");
+
+      // Check YAML frontmatter
+      expect(archiveContent).toContain("---");
+      expect(archiveContent).toContain("archived_at:");
+      expect(archiveContent).toContain("date_range:");
+      expect(archiveContent).toContain("entry_count: 10");
+
+      // Check markdown content
+      expect(archiveContent).toContain("# Archived Adventure History");
+      expect(archiveContent).toContain("## Entries");
+      expect(archiveContent).toContain("Player Input");
+      expect(archiveContent).toContain("GM Response");
+    });
+
+    test("creates archive directory if missing", async () => {
+      const history = createTestHistory(30);
+      const result = await compactor.compact(history);
+
+      expect(result.success).toBe(true);
+
+      // Check that history directory was created
+      const historyDir = join(TEST_ADVENTURE_DIR, "history");
+      const files = await readdir(historyDir);
+      expect(files.length).toBe(1);
+      expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}-\d{6}\.md$/);
+    });
+
+    test("generates mock summary in MOCK_SDK mode", async () => {
+      // The compactor uses env.mockSdk which defaults to false in tests
+      // But we can verify the structure even with mock
+      const history = createTestHistory(30);
+      const result = await compactor.compact(history);
+
+      expect(result.success).toBe(true);
+      expect(result.summary).toBeDefined();
+
+      if (result.summary) {
+        expect(result.summary.model).toBe("claude-haiku-3");
+        expect(result.summary.entriesArchived).toBe(10);
+        expect(result.summary.dateRange.from).toBeDefined();
+        expect(result.summary.dateRange.to).toBeDefined();
+        expect(result.summary.text).toBeDefined();
+        expect(result.summary.generatedAt).toBeDefined();
+      }
+    });
+
+    test("prevents concurrent compaction", async () => {
+      const history = createTestHistory(30);
+
+      // Start two compactions simultaneously
+      const promise1 = compactor.compact(history);
+      const promise2 = compactor.compact(history);
+
+      const [result1, result2] = await Promise.all([promise1, promise2]);
+
+      // One should succeed, one should fail with "already in progress"
+      const successes = [result1, result2].filter((r) => r.success);
+      const failures = [result1, result2].filter((r) => !r.success);
+
+      expect(successes.length).toBe(1);
+      expect(failures.length).toBe(1);
+      expect(failures[0].error).toContain("already in progress");
+    });
+
+    test("handles custom retention count", async () => {
+      const customCompactor = new HistoryCompactor(TEST_ADVENTURE_DIR, {
+        retainedCount: 10,
+        model: "claude-haiku-3",
+        mockSdk: true,
+      });
+
+      const history = createTestHistory(30);
+      const result = await customCompactor.compact(history);
+
+      expect(result.success).toBe(true);
+      expect(result.entriesArchived).toBe(20);
+      expect(result.retainedEntries).toHaveLength(10);
+    });
+  });
+
+  describe("date range calculation", () => {
+    test("calculates correct date range from entries", async () => {
+      const history = createTestHistory(30);
+      const result = await compactor.compact(history);
+
+      expect(result.success).toBe(true);
+      expect(result.summary?.dateRange.from).toBe(history.entries[0].timestamp);
+      expect(result.summary?.dateRange.to).toBe(history.entries[9].timestamp);
+    });
+  });
+
+  describe("archive filename format", () => {
+    test("generates timestamped filename", async () => {
+      const history = createTestHistory(30);
+      const result = await compactor.compact(history);
+
+      expect(result.success).toBe(true);
+      expect(result.archivePath).toMatch(/history\/\d{4}-\d{2}-\d{2}-\d{6}\.md$/);
+    });
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import {
 } from "./components";
 import { BackgroundLayer } from "./components/BackgroundLayer";
 import { useWebSocket } from "./hooks/useWebSocket";
-import type { ServerMessage, NarrativeEntry } from "../../shared/protocol";
+import type { ServerMessage, NarrativeEntry, HistorySummary } from "../../shared/protocol";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import "./App.css";
 
@@ -49,6 +49,9 @@ function GameView({
   const [narrativeHistory, setNarrativeHistory] = useState<NarrativeEntry[]>(
     []
   );
+  const [historySummary, setHistorySummary] = useState<HistorySummary | null>(
+    null
+  );
   const [streamingMessage, setStreamingMessage] =
     useState<StreamingMessage | null>(null);
   const [isGMResponding, setIsGMResponding] = useState(false);
@@ -57,8 +60,9 @@ function GameView({
   const handleMessage = useCallback((message: ServerMessage) => {
     switch (message.type) {
       case "adventure_loaded":
-        // Set initial history from server
+        // Set initial history and summary from server
         setNarrativeHistory(message.payload.history);
+        setHistorySummary(message.payload.summary ?? null);
         setError(null);
         break;
 
@@ -184,6 +188,7 @@ function GameView({
         <NarrativeLog
           entries={displayEntries}
           isStreaming={streamingMessage !== null}
+          summary={historySummary}
         />
 
         <div className="game-input-container">

--- a/frontend/src/components/HistorySummary.css
+++ b/frontend/src/components/HistorySummary.css
@@ -1,0 +1,57 @@
+/* HistorySummary styles */
+
+.history-summary {
+  margin-bottom: var(--spacing-lg);
+  padding: var(--spacing-md) var(--spacing-lg);
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--color-primary) 15%, transparent),
+    color-mix(in srgb, var(--color-surface) 80%, transparent)
+  );
+  border: 1px solid color-mix(in srgb, var(--color-primary) 30%, transparent);
+  border-radius: var(--radius-md);
+  border-left: 4px solid var(--color-primary);
+}
+
+.history-summary__header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+  font-weight: 600;
+  color: var(--color-primary);
+  font-size: var(--font-size-base);
+}
+
+.history-summary__icon {
+  font-size: 1.25em;
+}
+
+.history-summary__title {
+  font-style: italic;
+}
+
+.history-summary__content {
+  color: var(--color-text);
+  line-height: 1.6;
+  font-size: var(--font-size-sm);
+  white-space: pre-wrap;
+}
+
+.history-summary__meta {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-md);
+  padding-top: var(--spacing-sm);
+  border-top: 1px solid color-mix(in srgb, var(--color-border) 30%, transparent);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+}
+
+.history-summary__entries {
+  font-style: italic;
+}
+
+.history-summary__date {
+  font-weight: 500;
+}

--- a/frontend/src/components/HistorySummary.tsx
+++ b/frontend/src/components/HistorySummary.tsx
@@ -1,0 +1,43 @@
+import type { HistorySummary as HistorySummaryType } from "../types/protocol";
+import "./HistorySummary.css";
+
+interface HistorySummaryProps {
+  summary: HistorySummaryType;
+}
+
+/**
+ * Displays a summary of previously compacted history entries.
+ * Shown at the top of the narrative log when history has been archived.
+ */
+export function HistorySummary({ summary }: HistorySummaryProps) {
+  const fromDate = new Date(summary.dateRange.from);
+  const toDate = new Date(summary.dateRange.to);
+
+  // Format date range for display
+  const formatDate = (date: Date) =>
+    date.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+
+  const dateRange =
+    fromDate.toDateString() === toDate.toDateString()
+      ? formatDate(fromDate)
+      : `${formatDate(fromDate)} - ${formatDate(toDate)}`;
+
+  return (
+    <div className="history-summary" data-testid="history-summary">
+      <div className="history-summary__header">
+        <span className="history-summary__icon">&#128220;</span>
+        <span className="history-summary__title">Previously in your adventure...</span>
+      </div>
+      <div className="history-summary__content">{summary.text}</div>
+      <div className="history-summary__meta">
+        <span className="history-summary__entries">
+          {summary.entriesArchived} entries archived
+        </span>
+        <span className="history-summary__date">{dateRange}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/NarrativeLog.tsx
+++ b/frontend/src/components/NarrativeLog.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react";
-import type { NarrativeEntry as NarrativeEntryType } from "../types/protocol";
+import type {
+  NarrativeEntry as NarrativeEntryType,
+  HistorySummary as HistorySummaryType,
+} from "../types/protocol";
 import { NarrativeEntry } from "./NarrativeEntry";
+import { HistorySummary } from "./HistorySummary";
 import "./NarrativeLog.css";
 
 interface NarrativeLogProps {
@@ -10,9 +14,11 @@ interface NarrativeLogProps {
     text: string;
   };
   isStreaming?: boolean;
+  /** Summary of previously archived history entries */
+  summary?: HistorySummaryType | null;
 }
 
-export function NarrativeLog({ entries, streamingContent }: NarrativeLogProps) {
+export function NarrativeLog({ entries, streamingContent, summary }: NarrativeLogProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const previousEntriesLengthRef = useRef(entries.length);
   const previousStreamingTextRef = useRef(streamingContent?.text);
@@ -40,12 +46,13 @@ export function NarrativeLog({ entries, streamingContent }: NarrativeLogProps) {
       data-testid="narrative-log"
       className="narrative-log"
     >
-      {entries.length === 0 && !streamingContent ? (
+      {entries.length === 0 && !streamingContent && !summary ? (
         <div className="narrative-log__placeholder">
           No narrative entries yet. Start your adventure!
         </div>
       ) : (
         <>
+          {summary && <HistorySummary summary={summary} />}
           {entries.map((entry, index) => {
             // Check if this entry is currently streaming
             const isStreamingEntry =

--- a/frontend/src/types/protocol.ts
+++ b/frontend/src/types/protocol.ts
@@ -8,4 +8,5 @@ export type {
   Genre,
   Region,
   ThemeChangePayload,
+  HistorySummary,
 } from "../../../shared/protocol";

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -33,6 +33,45 @@ export const NarrativeEntrySchema = z.object({
 export type NarrativeEntry = z.infer<typeof NarrativeEntrySchema>;
 
 // ========================
+// History Compaction Types
+// ========================
+
+/**
+ * Summary of compacted history for context continuity.
+ * Generated when history.json exceeds the compaction threshold.
+ * Provides narrative recap for returning players.
+ */
+export const HistorySummarySchema = z.object({
+  /** When the summary was generated */
+  generatedAt: z.string(), // ISO 8601
+  /** Model used for summarization */
+  model: z.string(),
+  /** Number of entries that were archived */
+  entriesArchived: z.number(),
+  /** Date range covered by archived entries */
+  dateRange: z.object({
+    from: z.string(), // ISO 8601
+    to: z.string(), // ISO 8601
+  }),
+  /** The narrative summary text */
+  text: z.string(),
+});
+
+export type HistorySummary = z.infer<typeof HistorySummarySchema>;
+
+/**
+ * Narrative history with optional summary from compaction.
+ * The summary provides context for archived entries.
+ */
+export const NarrativeHistorySchema = z.object({
+  entries: z.array(NarrativeEntrySchema),
+  /** Summary of previously compacted entries (null if never compacted) */
+  summary: HistorySummarySchema.nullable().optional(),
+});
+
+export type NarrativeHistory = z.infer<typeof NarrativeHistorySchema>;
+
+// ========================
 // Dynamic Theming System Types
 // ========================
 
@@ -192,6 +231,8 @@ export const AdventureLoadedMessageSchema = z.object({
   payload: z.object({
     adventureId: z.string(),
     history: z.array(NarrativeEntrySchema),
+    /** Summary of previously compacted history (null if never compacted) */
+    summary: HistorySummarySchema.nullable().optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary

Implements automatic history compaction when `history.json` exceeds 100,000 characters:

- Archives older entries to dated markdown files in `adventures/<UUID>/history/`
- Generates AI summaries using Claude Haiku (~$0.001 per compaction)
- Retains last 20 entries for immediate context
- Displays summary at top of narrative log with distinct styling
- Triggers compaction on load for existing large histories

## Changes

**Backend:**
- `backend/src/services/history-compactor.ts` - Core compaction service with archiving and summarization
- `backend/src/adventure-state.ts` - Integrated async compaction on append and load
- `backend/src/env.ts` - New config vars (threshold, retention count, model)
- `backend/src/server.ts` - Include summary in `adventure_loaded` message
- `backend/src/types/state.ts` - CompactionConfig and CompactionResult types

**Frontend:**
- `frontend/src/components/HistorySummary.tsx` - Summary display component
- `frontend/src/components/NarrativeLog.tsx` - Renders summary above entries
- `frontend/src/App.tsx` - Handles summary state from server

**Shared:**
- `shared/protocol.ts` - HistorySummary schema and updated NarrativeHistory

## New Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `COMPACTION_CHAR_THRESHOLD` | 100000 | Character count to trigger compaction |
| `RETAINED_ENTRY_COUNT` | 20 | Entries kept after compaction |
| `COMPACTION_SUMMARY_MODEL` | claude-haiku-3 | Model for generating summaries |

## Test plan

- [x] Unit tests for history-compactor (14 tests)
- [x] All backend tests pass (421 tests)
- [x] All frontend tests pass (102 tests)
- [x] TypeScript compiles cleanly
- [x] ESLint passes

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)