### PR TITLE
feat(frontend): add integration tests for WebSocket message flows

### DIFF
--- a/e2e/message-flows.spec.ts
+++ b/e2e/message-flows.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * End-to-End Tests for Message Flow Scenarios
+ *
+ * Tests additional message flow scenarios that require full browser interaction
+ * including theme transitions, error handling, and edge cases.
+ *
+ * Prerequisites:
+ * - Backend running with MOCK_SDK=true
+ * - Frontend running on port 5173
+ */
+
+import { test, expect } from "@playwright/test";
+
+// Helper to clear localStorage state
+async function clearLocalStorage(page: Awaited<ReturnType<typeof import("@playwright/test").Page["context"]>>["pages"][0]) {
+  await page.evaluate(() => {
+    localStorage.clear();
+  });
+}
+
+// Helper to start a new adventure and wait for connection
+async function startNewAdventure(page: Awaited<ReturnType<typeof import("@playwright/test").Page["context"]>>["pages"][0]) {
+  await page.goto("/");
+  await clearLocalStorage(page);
+  await page.reload();
+
+  // Click "New Adventure" button
+  await page.getByRole("button", { name: /new adventure/i }).click();
+
+  // Wait for connected status
+  await expect(page.getByTestId("connection-status")).toContainText(
+    /connected/i,
+    { timeout: 5000 }
+  );
+
+  // Wait for input to be enabled
+  await expect(page.getByPlaceholder(/what do you do/i)).toBeEnabled({ timeout: 5000 });
+}
+
+test.describe("Message Flow E2E Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await clearLocalStorage(page);
+    await page.reload();
+  });
+
+  /**
+   * Test 1: Error Message Display and Dismissal
+   * Note: This requires the mock SDK to be configured to return errors
+   * Currently skipped as mock SDK doesn't have error triggering capability
+   */
+  test.skip("error message displays and can be dismissed", async ({ page }) => {
+    await startNewAdventure(page);
+
+    // Type a command that would trigger an error (if mock SDK supported it)
+    const input = page.getByPlaceholder(/what do you do/i);
+    await input.fill("trigger_error_command");
+    await input.press("Enter");
+
+    // Error message should appear
+    await expect(page.getByTestId("error-message")).toBeVisible({ timeout: 10000 });
+
+    // After successful response, error should clear
+    await input.fill("look around");
+    await input.press("Enter");
+
+    await expect(page.getByTestId("error-message")).not.toBeVisible({ timeout: 10000 });
+  });
+
+  /**
+   * Test 2: Input Keyboard Interaction
+   * Verifies real focus/blur behavior
+   */
+  test("input field keyboard interaction works correctly", async ({ page }) => {
+    await startNewAdventure(page);
+
+    const input = page.getByPlaceholder(/what do you do/i);
+
+    // Type a command
+    await input.focus();
+    await expect(input).toBeFocused();
+
+    await input.fill("look around");
+    expect(await input.inputValue()).toBe("look around");
+
+    // Press Enter to submit
+    await input.press("Enter");
+
+    // Input should be cleared after submission
+    await expect(input).toHaveValue("");
+
+    // Player input should appear in narrative
+    await expect(page.getByTestId("narrative-log")).toContainText("look around", { timeout: 5000 });
+  });
+
+  /**
+   * Test 3: Streaming Response Progressive Display
+   * Verifies streaming appears progressively
+   */
+  test("streaming response appears progressively", async ({ page }) => {
+    await startNewAdventure(page);
+
+    const input = page.getByPlaceholder(/what do you do/i);
+    await input.fill("tell me a story");
+    await input.press("Enter");
+
+    // Wait for streaming to start (input becomes disabled)
+    await expect(input).toHaveAttribute("placeholder", /waiting for response/i, { timeout: 5000 });
+
+    // Wait for narrative log to have content
+    const narrativeLog = page.getByTestId("narrative-log");
+    await expect(narrativeLog).toContainText(/./); // Any content
+
+    // Wait for streaming to end (input becomes enabled again)
+    await expect(input).toHaveAttribute("placeholder", /what do you do/i, { timeout: 30000 });
+
+    // Narrative should contain the response
+    await expect(narrativeLog).not.toBeEmpty();
+  });
+
+  /**
+   * Test 4: Multiple Rapid Inputs
+   * Verifies the system handles rapid input gracefully
+   */
+  test("handles multiple inputs in sequence", async ({ page }) => {
+    await startNewAdventure(page);
+
+    const input = page.getByPlaceholder(/what do you do/i);
+
+    // First input
+    await input.fill("first command");
+    await input.press("Enter");
+
+    // Wait for response to complete
+    await expect(input).toHaveAttribute("placeholder", /what do you do/i, { timeout: 30000 });
+
+    // Second input
+    await input.fill("second command");
+    await input.press("Enter");
+
+    // Wait for response to complete
+    await expect(input).toHaveAttribute("placeholder", /what do you do/i, { timeout: 30000 });
+
+    // Both inputs should be in narrative
+    const narrativeLog = page.getByTestId("narrative-log");
+    await expect(narrativeLog).toContainText("first command");
+    await expect(narrativeLog).toContainText("second command");
+  });
+
+  /**
+   * Test 5: Connection Status Updates
+   * Verifies connection status is displayed correctly
+   */
+  test("connection status updates correctly", async ({ page }) => {
+    await startNewAdventure(page);
+
+    // Should show connected
+    await expect(page.getByTestId("connection-status")).toContainText(/connected/i);
+
+    // The status indicator should be visible
+    await expect(page.getByTestId("connection-status")).toBeVisible();
+  });
+
+  /**
+   * Test 6: Quit Button Returns to Menu
+   * Verifies quit functionality
+   */
+  test("quit button returns to adventure menu", async ({ page }) => {
+    await startNewAdventure(page);
+
+    // Click quit button
+    await page.getByRole("button", { name: /quit/i }).click();
+
+    // Should be back at adventure menu
+    await expect(page.getByText("Adventure Engine of Corvran")).toBeVisible();
+    await expect(page.getByRole("button", { name: /new adventure/i })).toBeVisible();
+  });
+
+  /**
+   * Test 7: Page Refresh Preserves Adventure
+   * Verifies localStorage persistence
+   */
+  test("page refresh preserves current adventure", async ({ page }) => {
+    await startNewAdventure(page);
+
+    // Type a command
+    const input = page.getByPlaceholder(/what do you do/i);
+    await input.fill("look around");
+    await input.press("Enter");
+
+    // Wait for response
+    await expect(input).toHaveAttribute("placeholder", /what do you do/i, { timeout: 30000 });
+
+    // Get the adventure ID from the header
+    const adventureHeader = page.locator(".game-header__subtitle");
+    const adventureText = await adventureHeader.textContent();
+
+    // Refresh the page
+    await page.reload();
+
+    // Should still be in game view (localStorage has session)
+    await expect(page.getByTestId("connection-status")).toBeVisible({ timeout: 5000 });
+
+    // Adventure ID should be the same
+    await expect(adventureHeader).toContainText(adventureText?.replace("Adventure: ", "") ?? "");
+  });
+
+  /**
+   * Test 8: Long Response Handling
+   * Verifies long responses are handled correctly
+   */
+  test("handles long streaming responses", async ({ page }) => {
+    await startNewAdventure(page);
+
+    const input = page.getByPlaceholder(/what do you do/i);
+
+    // Request a longer response
+    await input.fill("tell me a very long and detailed story about everything");
+    await input.press("Enter");
+
+    // Wait for streaming to start
+    await expect(input).toHaveAttribute("placeholder", /waiting for response/i, { timeout: 5000 });
+
+    // Wait for streaming to complete (may take longer)
+    await expect(input).toHaveAttribute("placeholder", /what do you do/i, { timeout: 60000 });
+
+    // Narrative should have content
+    const narrativeLog = page.getByTestId("narrative-log");
+    const content = await narrativeLog.textContent();
+    expect(content?.length).toBeGreaterThan(100);
+  });
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -50,14 +50,14 @@ export default defineConfig({
   webServer: [
     {
       // Start backend with mock mode
-      command: `cd ../backend && MOCK_SDK=true bun src/index.ts`,
+      command: `cd ../backend && MOCK_SDK=true bun run start`,
       url: "http://localhost:3000",
       reuseExistingServer: !process.env.CI,
       timeout: 30_000,
     },
     {
       // Start frontend dev server
-      command: "cd ../frontend && npm run dev -- --port 5173",
+      command: "cd ../frontend && bun run dev -- --port 5173",
       url: "http://localhost:5173",
       reuseExistingServer: !process.env.CI,
       timeout: 30_000,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,7 +28,7 @@ function generateUUID(): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
-interface AdventureSession {
+export interface AdventureSession {
   adventureId: string;
   sessionToken: string;
 }
@@ -39,13 +39,15 @@ interface StreamingMessage {
   content: string;
 }
 
-function GameView({
-  session,
-  onQuit,
-}: {
+export interface GameViewProps {
   session: AdventureSession;
   onQuit: () => void;
-}) {
+}
+
+export function GameView({
+  session,
+  onQuit,
+}: GameViewProps) {
   const [narrativeHistory, setNarrativeHistory] = useState<NarrativeEntry[]>(
     []
   );

--- a/frontend/tests/integration/error-handling.test.tsx
+++ b/frontend/tests/integration/error-handling.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * Integration tests for error handling in message flows.
+ * Tests error display, recovery, and reconnection behavior.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "@testing-library/react";
+import {
+  renderGameView,
+  screen,
+  generateMessageId,
+  suppressConsoleError,
+  userEvent,
+  type ConsoleSpy,
+} from "./helpers/test-utils";
+
+describe("Error Handling Integration", { timeout: 15000 }, () => {
+  let consoleErrorSpy: ConsoleSpy;
+
+  beforeEach(() => {
+    consoleErrorSpy = suppressConsoleError();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("Error Message Display", () => {
+    test("INVALID_TOKEN error displays message", () => {
+      const { wsController } = renderGameView();
+
+      act(() => {
+        wsController.open();
+        wsController.simulateError("INVALID_TOKEN", "Invalid session token", false);
+      });
+
+      expect(screen.getByTestId("error-message")).toHaveTextContent("Invalid session token");
+    });
+
+    test("ADVENTURE_NOT_FOUND error displays message", () => {
+      const { wsController } = renderGameView();
+
+      act(() => {
+        wsController.open();
+        wsController.simulateError("ADVENTURE_NOT_FOUND", "Adventure not found", false);
+      });
+
+      expect(screen.getByTestId("error-message")).toHaveTextContent("Adventure not found");
+    });
+
+    test("RATE_LIMIT error displays with retry indication", () => {
+      const { wsController } = renderGameView();
+
+      act(() => {
+        wsController.simulateAuthentication();
+        wsController.simulateError("RATE_LIMIT", "Too many requests. Please try again later.", true);
+      });
+
+      expect(screen.getByTestId("error-message")).toHaveTextContent("Too many requests");
+    });
+
+    test("GM_ERROR clears streaming state", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "test{Enter}");
+
+      const messageId = generateMessageId();
+
+      // Start streaming
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "Partial response..." },
+        });
+      });
+
+      // Should be streaming
+      expect(screen.getByPlaceholderText("Waiting for response...")).toBeDisabled();
+
+      // Error occurs
+      act(() => {
+        wsController.simulateError("GM_ERROR", "An error occurred processing your request", true);
+      });
+
+      // Error displayed
+      expect(screen.getByTestId("error-message")).toHaveTextContent("An error occurred");
+
+      // Streaming should stop, input enabled
+      expect(screen.getByPlaceholderText("What do you do?")).not.toBeDisabled();
+    });
+
+    test("STATE_CORRUPTED error displays message", () => {
+      const { wsController } = renderGameView();
+
+      act(() => {
+        wsController.open();
+        wsController.simulateError("STATE_CORRUPTED", "Adventure state is corrupted", false);
+      });
+
+      expect(screen.getByTestId("error-message")).toHaveTextContent("Adventure state is corrupted");
+    });
+
+    test("PROCESSING_TIMEOUT error displays message", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "complex request{Enter}");
+
+      act(() => {
+        wsController.simulateError("PROCESSING_TIMEOUT", "Request timed out", true);
+      });
+
+      expect(screen.getByTestId("error-message")).toHaveTextContent("Request timed out");
+    });
+  });
+
+  describe("Error Recovery", () => {
+    test("error clears on next successful gm_response_start", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // First request fails
+      let input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "first request{Enter}");
+
+      act(() => {
+        wsController.simulateError("GM_ERROR", "Temporary error", true);
+      });
+
+      expect(screen.getByTestId("error-message")).toBeInTheDocument();
+
+      // Second request succeeds
+      input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "second request{Enter}");
+
+      const messageId = generateMessageId();
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+      });
+
+      // Error should be cleared
+      expect(screen.queryByTestId("error-message")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Connection Status", () => {
+    test("WebSocket close triggers reconnecting status", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // Connection is lost
+      act(() => {
+        wsController.close(1006, "Connection lost");
+      });
+
+      // Input should show reconnecting
+      expect(screen.getByPlaceholderText("Reconnecting...")).toBeInTheDocument();
+      vi.useRealTimers();
+    });
+
+    test("reconnect success restores connected status", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // Connection is lost
+      act(() => {
+        wsController.close(1006, "Connection lost");
+      });
+
+      expect(screen.getByPlaceholderText("Reconnecting...")).toBeInTheDocument();
+
+      // Advance time for reconnect attempt
+      act(() => {
+        vi.advanceTimersByTime(1500);
+      });
+
+      // Simulate reconnection
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // Should be connected again
+      expect(screen.getByPlaceholderText("What do you do?")).not.toBeDisabled();
+      vi.useRealTimers();
+    });
+  });
+
+  describe("Input State After Error", () => {
+    test("input is enabled after non-retryable error", () => {
+      const { wsController } = renderGameView();
+
+      act(() => {
+        wsController.simulateAuthentication();
+        wsController.simulateError("STATE_CORRUPTED", "Fatal error", false);
+      });
+
+      // Input should still be enabled (user might want to try something)
+      const input = screen.getByPlaceholderText("What do you do?");
+      expect(input).not.toBeDisabled();
+    });
+
+    test("input is enabled after retryable error", () => {
+      const { wsController } = renderGameView();
+
+      act(() => {
+        wsController.simulateAuthentication();
+        wsController.simulateError("RATE_LIMIT", "Please wait", true);
+      });
+
+      // Input should be enabled for retry
+      const input = screen.getByPlaceholderText("What do you do?");
+      expect(input).not.toBeDisabled();
+    });
+  });
+});

--- a/frontend/tests/integration/helpers/test-utils.tsx
+++ b/frontend/tests/integration/helpers/test-utils.tsx
@@ -1,0 +1,442 @@
+/**
+ * Test utilities for integration tests.
+ * Provides helpers to render GameView with providers and control MockWebSocket.
+ */
+
+import { render, screen, type RenderResult, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi, type MockInstance } from "vitest";
+import type { ReactNode } from "react";
+import { ThemeProvider } from "../../../src/contexts/ThemeContext";
+import { GameView, type AdventureSession } from "../../../src/App";
+import type {
+  ServerMessage,
+  ClientMessage,
+  NarrativeEntry,
+  ThemeMood,
+  ErrorCode,
+  HistorySummary,
+} from "../../../../shared/protocol";
+
+// Re-export screen and waitFor for convenience
+export { screen, waitFor };
+
+// Re-export userEvent for convenience
+export { userEvent };
+
+// Track the current MockWebSocket instance globally
+let currentMockWebSocket: EnhancedMockWebSocket | null = null;
+const sentMessagesStore: ClientMessage[] = [];
+
+// Interface for MockWebSocket with test helpers - defined early for use in TrackedMockWebSocket
+interface EnhancedMockWebSocket {
+  url: string;
+  readyState: number;
+  send: (data: string) => void;
+  close: (code?: number, reason?: string) => void;
+  simulateOpen: () => void;
+  simulateMessage: (data: unknown) => void;
+  simulateClose: (code?: number, reason?: string) => void;
+  simulateError: () => void;
+}
+
+class TrackedMockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  readyState: number = TrackedMockWebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    currentMockWebSocket = this as unknown as EnhancedMockWebSocket;
+    // Clear sent messages on new connection
+    sentMessagesStore.length = 0;
+  }
+
+  send(data: string): void {
+    try {
+      const parsed = JSON.parse(data) as ClientMessage;
+      sentMessagesStore.push(parsed);
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  close(): void {
+    this.readyState = TrackedMockWebSocket.CLOSED;
+  }
+
+  // Test helpers
+  simulateOpen(): void {
+    this.readyState = TrackedMockWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  simulateMessage(data: unknown): void {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+
+  simulateClose(code = 1000, reason = ""): void {
+    this.readyState = TrackedMockWebSocket.CLOSED;
+    this.onclose?.(new CloseEvent("close", { code, reason }));
+  }
+
+  simulateError(): void {
+    this.onerror?.(new Event("error"));
+  }
+}
+
+// Replace global WebSocket
+// @ts-expect-error - replacing for testing
+globalThis.WebSocket = TrackedMockWebSocket;
+
+// Mock Element.scrollTo (not available in jsdom)
+Element.prototype.scrollTo = vi.fn();
+
+/**
+ * Enhanced MockWebSocket controller that provides helpers.
+ */
+export class MockWebSocketController {
+  constructor() {
+    // Reset state
+    currentMockWebSocket = null;
+    sentMessagesStore.length = 0;
+  }
+
+  private get instance(): EnhancedMockWebSocket | null {
+    return currentMockWebSocket;
+  }
+
+  private get sentMessages(): ClientMessage[] {
+    return sentMessagesStore;
+  }
+
+  /**
+   * Get the current MockWebSocket instance.
+   */
+  getInstance(): EnhancedMockWebSocket | null {
+    return this.instance;
+  }
+
+  /**
+   * Simulate WebSocket connection opening.
+   */
+  open(): void {
+    if (!this.instance) {
+      throw new Error("WebSocket not created yet");
+    }
+    this.instance.simulateOpen();
+  }
+
+  /**
+   * Simulate receiving a server message.
+   */
+  receiveMessage(message: ServerMessage): void {
+    if (!this.instance) {
+      throw new Error("WebSocket not created yet");
+    }
+    this.instance.simulateMessage(message);
+  }
+
+  /**
+   * Simulate WebSocket close event.
+   */
+  close(code = 1000, reason = ""): void {
+    if (!this.instance) {
+      throw new Error("WebSocket not created yet");
+    }
+    this.instance.simulateClose(code, reason);
+  }
+
+  /**
+   * Simulate WebSocket error event.
+   */
+  error(): void {
+    if (!this.instance) {
+      throw new Error("WebSocket not created yet");
+    }
+    this.instance.simulateError();
+  }
+
+  /**
+   * Get all messages sent by the client.
+   */
+  getSentMessages(): ClientMessage[] {
+    return [...this.sentMessages];
+  }
+
+  /**
+   * Get the last message sent by the client.
+   */
+  getLastSentMessage(): ClientMessage | undefined {
+    return this.sentMessages[this.sentMessages.length - 1];
+  }
+
+  /**
+   * Clear sent message history.
+   */
+  clearSentMessages(): void {
+    sentMessagesStore.length = 0;
+  }
+
+  /**
+   * Simulate full authentication flow: open → adventure_loaded.
+   */
+  simulateAuthentication(options: {
+    adventureId?: string;
+    history?: NarrativeEntry[];
+    summary?: HistorySummary | null;
+  } = {}): void {
+    const {
+      adventureId = "test-adventure-id",
+      history = [],
+      summary = null,
+    } = options;
+
+    this.open();
+    this.receiveMessage({
+      type: "adventure_loaded",
+      payload: {
+        adventureId,
+        history,
+        summary,
+      },
+    });
+  }
+
+  /**
+   * Simulate a complete GM response (start → chunks → end).
+   */
+  simulatePlayerResponse(messageId: string, chunks: string[]): void {
+    // Start
+    this.receiveMessage({
+      type: "gm_response_start",
+      payload: { messageId },
+    });
+
+    // Chunks
+    for (const text of chunks) {
+      this.receiveMessage({
+        type: "gm_response_chunk",
+        payload: { messageId, text },
+      });
+    }
+
+    // End
+    this.receiveMessage({
+      type: "gm_response_end",
+      payload: { messageId },
+    });
+  }
+
+  /**
+   * Simulate a theme change message.
+   */
+  simulateThemeChange(
+    mood: ThemeMood,
+    options: {
+      genre?: "sci-fi" | "steampunk" | "low-fantasy" | "high-fantasy" | "horror" | "modern" | "historical";
+      region?: "city" | "village" | "forest" | "desert" | "mountain" | "ocean" | "underground" | "castle" | "ruins";
+      backgroundUrl?: string | null;
+      transitionDuration?: number;
+    } = {}
+  ): void {
+    const {
+      genre = "low-fantasy",
+      region = "forest",
+      backgroundUrl = null,
+      transitionDuration,
+    } = options;
+
+    this.receiveMessage({
+      type: "theme_change",
+      payload: {
+        mood,
+        genre,
+        region,
+        backgroundUrl,
+        ...(transitionDuration !== undefined && { transitionDuration }),
+      },
+    });
+  }
+
+  /**
+   * Simulate an error message.
+   */
+  simulateError(code: ErrorCode, message: string, retryable: boolean): void {
+    this.receiveMessage({
+      type: "error",
+      payload: { code, message, retryable },
+    });
+  }
+
+  /**
+   * Simulate a pong response.
+   */
+  simulatePong(): void {
+    this.receiveMessage({ type: "pong" });
+  }
+}
+
+/**
+ * Create a mock NarrativeEntry for testing.
+ */
+export function createMockEntry(
+  type: "player_input" | "gm_response",
+  content: string,
+  options: { id?: string; timestamp?: string } = {}
+): NarrativeEntry {
+  return {
+    id: options.id ?? `entry-${Math.random().toString(36).slice(2)}`,
+    timestamp: options.timestamp ?? new Date().toISOString(),
+    type,
+    content,
+  };
+}
+
+/**
+ * Create a mock history with alternating player/GM entries.
+ */
+export function createMockHistory(count: number): NarrativeEntry[] {
+  const entries: NarrativeEntry[] = [];
+  for (let i = 0; i < count; i++) {
+    const type = i % 2 === 0 ? "player_input" : "gm_response";
+    entries.push(
+      createMockEntry(type, `${type === "player_input" ? "Player" : "GM"} message ${i + 1}`)
+    );
+  }
+  return entries;
+}
+
+/**
+ * Create a mock HistorySummary for testing.
+ */
+export function createMockSummary(text: string): HistorySummary {
+  return {
+    generatedAt: new Date().toISOString(),
+    model: "claude-3-5-haiku-20241022",
+    entriesArchived: 50,
+    dateRange: {
+      from: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+      to: new Date().toISOString(),
+    },
+    text,
+  };
+}
+
+/**
+ * Wrapper component with all necessary providers.
+ */
+function TestProviders({ children }: { children: ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+/**
+ * Render options for renderWithProviders.
+ */
+interface RenderWithProvidersOptions {
+  wsController?: MockWebSocketController;
+}
+
+/**
+ * Render a component with all necessary providers.
+ * Returns render result plus WebSocket controller.
+ */
+export function renderWithProviders(
+  ui: React.ReactElement,
+  options: RenderWithProvidersOptions = {}
+): RenderResult & { wsController: MockWebSocketController } {
+  const wsController = options.wsController ?? new MockWebSocketController();
+
+  const result = render(ui, {
+    wrapper: TestProviders,
+  });
+
+  return {
+    ...result,
+    wsController,
+  };
+}
+
+/**
+ * Generate a random UUID for message IDs.
+ */
+export function generateMessageId(): string {
+  return `msg-${Math.random().toString(36).slice(2)}-${Date.now()}`;
+}
+
+type ConsoleSpy = MockInstance<typeof console.error>;
+
+/**
+ * Suppress console.error for expected errors.
+ * Call mockRestore() when done.
+ */
+export function suppressConsoleError(): ConsoleSpy {
+  return vi.spyOn(console, "error").mockImplementation(() => {});
+}
+
+/**
+ * Suppress console.warn for expected warnings.
+ * Call mockRestore() when done.
+ */
+export function suppressConsoleWarn(): MockInstance<typeof console.warn> {
+  return vi.spyOn(console, "warn").mockImplementation(() => {});
+}
+
+// Export the type for use in test files
+export type { ConsoleSpy };
+
+/**
+ * Options for renderGameView.
+ */
+interface RenderGameViewOptions {
+  adventureId?: string;
+  sessionToken?: string;
+  onQuit?: () => void;
+}
+
+/**
+ * Result from renderGameView.
+ */
+interface RenderGameViewResult extends RenderResult {
+  wsController: MockWebSocketController;
+  user: ReturnType<typeof userEvent.setup>;
+  session: AdventureSession;
+}
+
+/**
+ * Render GameView with all providers and return controller for testing.
+ */
+export function renderGameView(
+  options: RenderGameViewOptions = {}
+): RenderGameViewResult {
+  const {
+    adventureId = "test-adventure-id",
+    sessionToken = "test-session-token",
+    onQuit = vi.fn(),
+  } = options;
+
+  const session: AdventureSession = { adventureId, sessionToken };
+  const wsController = new MockWebSocketController();
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+  const result = render(
+    <ThemeProvider>
+      <GameView session={session} onQuit={onQuit} />
+    </ThemeProvider>
+  );
+
+  return {
+    ...result,
+    wsController,
+    user,
+    session,
+  };
+}

--- a/frontend/tests/integration/message-flows.test.tsx
+++ b/frontend/tests/integration/message-flows.test.tsx
@@ -1,0 +1,505 @@
+/**
+ * Integration tests for core WebSocket message flows.
+ * Tests the complete message lifecycle through the GameView component.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "@testing-library/react";
+import {
+  renderGameView,
+  screen,
+  createMockEntry,
+  createMockSummary,
+  generateMessageId,
+  suppressConsoleError,
+  userEvent,
+  type ConsoleSpy,
+} from "./helpers/test-utils";
+
+// Increase timeout for integration tests that use userEvent
+// (typing simulation takes time)
+describe("Message Flows Integration", { timeout: 15000 }, () => {
+  let consoleErrorSpy: ConsoleSpy;
+
+  beforeEach(() => {
+    consoleErrorSpy = suppressConsoleError();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("Connection and Authentication", () => {
+    test("sends authenticate and start_adventure on connection", () => {
+      const { wsController } = renderGameView();
+
+      // WebSocket should be created
+      expect(wsController.getInstance()).not.toBeNull();
+
+      // Simulate connection opening
+      act(() => {
+        wsController.open();
+      });
+
+      const messages = wsController.getSentMessages();
+
+      // Should send authenticate first
+      expect(messages[0]).toEqual({
+        type: "authenticate",
+        payload: { token: "test-session-token" },
+      });
+
+      // Then start_adventure
+      expect(messages[1]).toEqual({
+        type: "start_adventure",
+        payload: { adventureId: "test-adventure-id" },
+      });
+    });
+
+    test("displays empty state before adventure loaded", () => {
+      renderGameView();
+
+      // Should show the placeholder text
+      expect(screen.getByText(/no narrative entries yet/i)).toBeInTheDocument();
+    });
+
+    test("displays history after adventure_loaded message", () => {
+      const { wsController } = renderGameView();
+      const history = [
+        createMockEntry("player_input", "Hello, world!"),
+        createMockEntry("gm_response", "Welcome to the adventure."),
+      ];
+
+      act(() => {
+        wsController.simulateAuthentication({ history });
+      });
+
+      // History should be displayed
+      expect(screen.getByText("Hello, world!")).toBeInTheDocument();
+      expect(screen.getByText("Welcome to the adventure.")).toBeInTheDocument();
+    });
+
+    test("displays history summary when provided", () => {
+      const { wsController } = renderGameView();
+      const summary = createMockSummary("Previously on your adventure: You found a mysterious key.");
+
+      act(() => {
+        wsController.simulateAuthentication({ summary });
+      });
+
+      // Summary should be displayed
+      expect(screen.getByText(/Previously on your adventure/)).toBeInTheDocument();
+    });
+
+    test("status becomes connected after WebSocket opens", () => {
+      const { wsController } = renderGameView();
+
+      // Initially should show disconnected state (input disabled)
+      const inputBefore = screen.getByPlaceholderText("Reconnecting...");
+      expect(inputBefore).toBeDisabled();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // After connected, input should be enabled
+      const inputAfter = screen.getByPlaceholderText("What do you do?");
+      expect(inputAfter).not.toBeDisabled();
+    });
+  });
+
+  describe("Player Input Flow", () => {
+    test("player input appears immediately in narrative", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // Type and submit input
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "look around{Enter}");
+
+      // Player input should appear immediately
+      expect(screen.getByText("look around")).toBeInTheDocument();
+    });
+
+    test("sends player_input message with correct payload", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      wsController.clearSentMessages();
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "examine the door{Enter}");
+
+      const messages = wsController.getSentMessages();
+      expect(messages).toContainEqual({
+        type: "player_input",
+        payload: { text: "examine the door" },
+      });
+    });
+
+    test("clears input field after submission", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "test input{Enter}");
+
+      expect(input).toHaveValue("");
+    });
+  });
+
+  describe("GM Response Streaming", () => {
+    test("gm_response_start enables streaming indicator", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "look around{Enter}");
+
+      // Start streaming response
+      const messageId = generateMessageId();
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+      });
+
+      // Input should show "Waiting for response..."
+      expect(screen.getByPlaceholderText("Waiting for response...")).toBeInTheDocument();
+    });
+
+    test("gm_response_chunks accumulate content", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "look around{Enter}");
+
+      const messageId = generateMessageId();
+
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+      });
+
+      // Send first chunk
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "You see a " },
+        });
+      });
+
+      expect(screen.getByText("You see a")).toBeInTheDocument();
+
+      // Send second chunk
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "dark forest." },
+        });
+      });
+
+      expect(screen.getByText("You see a dark forest.")).toBeInTheDocument();
+    });
+
+    test("gm_response_end finalizes entry and enables input", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "look around{Enter}");
+
+      const messageId = generateMessageId();
+
+      // Complete streaming sequence
+      act(() => {
+        wsController.simulatePlayerResponse(messageId, ["The room is dark and quiet."]);
+      });
+
+      // Response should be in the narrative
+      expect(screen.getByText("The room is dark and quiet.")).toBeInTheDocument();
+
+      // Input should be enabled again
+      expect(screen.getByPlaceholderText("What do you do?")).not.toBeDisabled();
+    });
+
+    test("full input→response cycle works end-to-end", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // Player submits input
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "open the chest{Enter}");
+
+      // Server responds with streaming message
+      const messageId = generateMessageId();
+      act(() => {
+        wsController.simulatePlayerResponse(messageId, [
+          "You open the chest and find ",
+          "a shimmering golden key.",
+        ]);
+      });
+
+      // Both player input and GM response should be visible
+      expect(screen.getByText("open the chest")).toBeInTheDocument();
+      expect(screen.getByText("You open the chest and find a shimmering golden key.")).toBeInTheDocument();
+    });
+
+    test("multiple exchanges maintain correct order", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // First exchange
+      let input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "first command{Enter}");
+
+      act(() => {
+        wsController.simulatePlayerResponse(generateMessageId(), ["First response."]);
+      });
+
+      // Second exchange
+      input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "second command{Enter}");
+
+      act(() => {
+        wsController.simulatePlayerResponse(generateMessageId(), ["Second response."]);
+      });
+
+      // Third exchange
+      input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "third command{Enter}");
+
+      act(() => {
+        wsController.simulatePlayerResponse(generateMessageId(), ["Third response."]);
+      });
+
+      // All entries should be visible
+      const log = screen.getByTestId("narrative-log");
+      expect(log.textContent).toContain("first command");
+      expect(log.textContent).toContain("First response.");
+      expect(log.textContent).toContain("second command");
+      expect(log.textContent).toContain("Second response.");
+      expect(log.textContent).toContain("third command");
+      expect(log.textContent).toContain("Third response.");
+    });
+  });
+
+  describe("Heartbeat", () => {
+    test("sends ping every 30 seconds", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      wsController.clearSentMessages();
+
+      // Advance 30 seconds
+      act(() => {
+        vi.advanceTimersByTime(30000);
+      });
+
+      const messages = wsController.getSentMessages();
+      expect(messages).toContainEqual({ type: "ping" });
+      vi.useRealTimers();
+    });
+
+    test("handles pong response without errors", () => {
+      const { wsController } = renderGameView();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // Send pong (should not cause any issues)
+      act(() => {
+        wsController.simulatePong();
+      });
+
+      // No errors should be logged
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Edge Cases", () => {
+    test("mismatched messageId is ignored", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "test{Enter}");
+
+      const correctId = generateMessageId();
+      const wrongId = generateMessageId();
+
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId: correctId },
+        });
+      });
+
+      // Send chunk with wrong ID
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId: wrongId, text: "This should be ignored" },
+        });
+      });
+
+      // Send chunk with correct ID
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId: correctId, text: "Correct content" },
+        });
+      });
+
+      // Only correct content should be visible
+      expect(screen.getByText("Correct content")).toBeInTheDocument();
+      expect(screen.queryByText("This should be ignored")).not.toBeInTheDocument();
+    });
+
+    test("duplicate gm_response_end does not create duplicate entry", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "test{Enter}");
+
+      const messageId = generateMessageId();
+
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "Response content" },
+        });
+        wsController.receiveMessage({
+          type: "gm_response_end",
+          payload: { messageId },
+        });
+      });
+
+      // Send duplicate end
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_end",
+          payload: { messageId },
+        });
+      });
+
+      // Should only have one GM response entry
+      const responses = screen.getAllByText("Response content");
+      expect(responses).toHaveLength(1);
+    });
+
+    test("empty chunk does not crash", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "test{Enter}");
+
+      const messageId = generateMessageId();
+
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "" },
+        });
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "Content after empty" },
+        });
+        wsController.receiveMessage({
+          type: "gm_response_end",
+          payload: { messageId },
+        });
+      });
+
+      expect(screen.getByText("Content after empty")).toBeInTheDocument();
+    });
+
+    test("large response renders correctly", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "tell me a long story{Enter}");
+
+      const messageId = generateMessageId();
+      const largeContent = "A".repeat(10000); // 10KB of content
+
+      act(() => {
+        wsController.simulatePlayerResponse(messageId, [largeContent]);
+      });
+
+      // Should contain the large content
+      const log = screen.getByTestId("narrative-log");
+      expect(log.textContent).toContain(largeContent);
+    });
+  });
+});

--- a/frontend/tests/integration/streaming-narrative.test.tsx
+++ b/frontend/tests/integration/streaming-narrative.test.tsx
@@ -1,0 +1,344 @@
+/**
+ * Integration tests for streaming narrative display.
+ * Tests progressive display, auto-scroll, and transition behavior.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "@testing-library/react";
+import {
+  renderGameView,
+  screen,
+  generateMessageId,
+  suppressConsoleError,
+  userEvent,
+  type ConsoleSpy,
+} from "./helpers/test-utils";
+
+describe("Streaming Narrative Integration", { timeout: 15000 }, () => {
+  let consoleErrorSpy: ConsoleSpy;
+
+  beforeEach(() => {
+    consoleErrorSpy = suppressConsoleError();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe("Progressive Display", () => {
+    test("streaming content appears incrementally", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "describe the scene{Enter}");
+
+      const messageId = generateMessageId();
+
+      // Start streaming
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+      });
+
+      // First chunk
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "The sun sets " },
+        });
+      });
+
+      expect(screen.getByText("The sun sets")).toBeInTheDocument();
+
+      // Second chunk
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "over the mountains, " },
+        });
+      });
+
+      expect(screen.getByText("The sun sets over the mountains,")).toBeInTheDocument();
+
+      // Third chunk
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "painting the sky orange." },
+        });
+      });
+
+      expect(screen.getByText("The sun sets over the mountains, painting the sky orange.")).toBeInTheDocument();
+    });
+
+    test("streaming entry shows visual indicator via isStreaming prop", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "test{Enter}");
+
+      const messageId = generateMessageId();
+
+      // Before streaming, no streaming class
+      const logBefore = screen.getByTestId("narrative-log");
+      expect(logBefore.querySelector(".streaming")).toBeNull();
+
+      // Start streaming
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "Content" },
+        });
+      });
+
+      // During streaming, should have streaming indicator
+      // (implementation may vary - checking the input placeholder as proxy)
+      expect(screen.getByPlaceholderText("Waiting for response...")).toBeInTheDocument();
+
+      // End streaming
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_end",
+          payload: { messageId },
+        });
+      });
+
+      // After streaming ends, input should be enabled
+      expect(screen.getByPlaceholderText("What do you do?")).not.toBeDisabled();
+    });
+  });
+
+  describe("Auto-scroll Behavior", () => {
+    test("scrollTo is called when new streaming content arrives", async () => {
+      const scrollToSpy = vi.spyOn(Element.prototype, "scrollTo");
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "test{Enter}");
+
+      scrollToSpy.mockClear();
+
+      const messageId = generateMessageId();
+
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "New content" },
+        });
+      });
+
+      // scrollTo should be called for new content
+      expect(scrollToSpy).toHaveBeenCalled();
+
+      scrollToSpy.mockRestore();
+    });
+  });
+
+  describe("Rapid Chunks", () => {
+    test("handles 50 chunks in quick succession", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "rapid test{Enter}");
+
+      const messageId = generateMessageId();
+
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+      });
+
+      // Send 50 chunks rapidly
+      act(() => {
+        for (let i = 0; i < 50; i++) {
+          wsController.receiveMessage({
+            type: "gm_response_chunk",
+            payload: { messageId, text: `chunk${i} ` },
+          });
+        }
+      });
+
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_end",
+          payload: { messageId },
+        });
+      });
+
+      // All chunks should be present
+      const log = screen.getByTestId("narrative-log");
+      expect(log.textContent).toContain("chunk0");
+      expect(log.textContent).toContain("chunk49");
+    });
+  });
+
+  describe("Multi-paragraph Content", () => {
+    test("preserves line breaks in streaming content", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "describe{Enter}");
+
+      const messageId = generateMessageId();
+      const multiParagraph = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.";
+
+      act(() => {
+        wsController.simulatePlayerResponse(messageId, [multiParagraph]);
+      });
+
+      // The content should be present (newlines may be rendered as breaks or preserved)
+      const log = screen.getByTestId("narrative-log");
+      expect(log.textContent).toContain("First paragraph.");
+      expect(log.textContent).toContain("Second paragraph.");
+      expect(log.textContent).toContain("Third paragraph.");
+    });
+  });
+
+  describe("Markdown Content", () => {
+    test("markdown renders during streaming", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "markdown test{Enter}");
+
+      const messageId = generateMessageId();
+
+      act(() => {
+        wsController.simulatePlayerResponse(messageId, [
+          "Here is some **bold** and *italic* text.",
+        ]);
+      });
+
+      // Check that markdown is rendered (bold and italic)
+      const log = screen.getByTestId("narrative-log");
+      expect(log.querySelector("strong")).not.toBeNull();
+      expect(log.querySelector("em")).not.toBeNull();
+    });
+  });
+
+  describe("Transition to History", () => {
+    test("streaming entry transitions to history entry on completion", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "transition test{Enter}");
+
+      const messageId = generateMessageId();
+
+      // During streaming
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+        wsController.receiveMessage({
+          type: "gm_response_chunk",
+          payload: { messageId, text: "Streaming content" },
+        });
+      });
+
+      // Content visible during streaming
+      expect(screen.getByText("Streaming content")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Waiting for response...")).toBeInTheDocument();
+
+      // End streaming
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_end",
+          payload: { messageId },
+        });
+      });
+
+      // Content still visible as history entry
+      expect(screen.getByText("Streaming content")).toBeInTheDocument();
+
+      // Input enabled (streaming ended)
+      expect(screen.getByPlaceholderText("What do you do?")).not.toBeDisabled();
+    });
+  });
+
+  describe("Input During Stream", () => {
+    test("input is disabled while streaming", async () => {
+      const { wsController } = renderGameView();
+      const user = userEvent.setup();
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "test{Enter}");
+
+      const messageId = generateMessageId();
+
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_start",
+          payload: { messageId },
+        });
+      });
+
+      // Input should be disabled during streaming
+      expect(screen.getByPlaceholderText("Waiting for response...")).toBeDisabled();
+
+      act(() => {
+        wsController.receiveMessage({
+          type: "gm_response_end",
+          payload: { messageId },
+        });
+      });
+
+      // Input should be enabled after streaming
+      expect(screen.getByPlaceholderText("What do you do?")).not.toBeDisabled();
+    });
+  });
+});

--- a/frontend/tests/integration/theme-integration.test.tsx
+++ b/frontend/tests/integration/theme-integration.test.tsx
@@ -1,0 +1,318 @@
+/**
+ * Integration tests for theme change handling through the component tree.
+ * Tests CSS variable application, background updates, and mood transitions.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "@testing-library/react";
+import {
+  renderGameView,
+  screen,
+  suppressConsoleError,
+  suppressConsoleWarn,
+  userEvent,
+  type ConsoleSpy,
+} from "./helpers/test-utils";
+import type { ThemeMood } from "../../../shared/protocol";
+
+describe("Theme Integration", { timeout: 15000 }, () => {
+  let consoleErrorSpy: ConsoleSpy;
+  let consoleWarnSpy: ConsoleSpy;
+
+  beforeEach(() => {
+    consoleErrorSpy = suppressConsoleError();
+    consoleWarnSpy = suppressConsoleWarn();
+    // Clear any existing styles
+    document.documentElement.removeAttribute("style");
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    document.documentElement.removeAttribute("style");
+  });
+
+  describe("CSS Variable Application", () => {
+    test("theme_change applies CSS variables to document", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      // Advance past initial debounce
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      act(() => {
+        wsController.simulateThemeChange("tense");
+      });
+
+      const root = document.documentElement;
+      expect(root.style.getPropertyValue("--color-primary")).toBe("#c65900");
+      vi.useRealTimers();
+    });
+
+    test("all mood values apply correct colors", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      const moodColors: Record<ThemeMood, string> = {
+        calm: "#2196f3",
+        tense: "#c65900",
+        ominous: "#ba68c8",
+        triumphant: "#b8860b",
+        mysterious: "#00bcd4",
+      };
+
+      for (const [mood, expectedColor] of Object.entries(moodColors)) {
+        act(() => {
+          vi.advanceTimersByTime(1100); // Advance past debounce
+        });
+
+        act(() => {
+          wsController.simulateThemeChange(mood as ThemeMood);
+        });
+
+        const root = document.documentElement;
+        expect(root.style.getPropertyValue("--color-primary")).toBe(expectedColor);
+      }
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("Background URL Handling", () => {
+    test("theme_change with backgroundUrl updates BackgroundLayer", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      act(() => {
+        wsController.simulateThemeChange("mysterious", {
+          backgroundUrl: "https://example.com/bg.jpg",
+        });
+      });
+
+      // BackgroundLayer should receive the URL
+      // (The actual image loading is tested in BackgroundLayer unit tests)
+      // Here we verify the theme context updates
+      const root = document.documentElement;
+      expect(root.style.getPropertyValue("--color-primary")).toBe("#00bcd4");
+      vi.useRealTimers();
+    });
+
+    test("theme_change with null backgroundUrl clears background", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // First set a background
+      act(() => {
+        wsController.simulateThemeChange("calm", {
+          backgroundUrl: "https://example.com/bg1.jpg",
+        });
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      // Then clear it
+      act(() => {
+        wsController.simulateThemeChange("tense", {
+          backgroundUrl: null,
+        });
+      });
+
+      // Theme should still apply
+      const root = document.documentElement;
+      expect(root.style.getPropertyValue("--color-primary")).toBe("#c65900");
+      vi.useRealTimers();
+    });
+  });
+
+  describe("Theme Debouncing", () => {
+    test("rapid theme changes are debounced", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // Send multiple theme changes rapidly
+      act(() => {
+        wsController.simulateThemeChange("calm");
+        wsController.simulateThemeChange("tense");
+        wsController.simulateThemeChange("ominous");
+      });
+
+      // Without advancing time, the last theme should win after debounce
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      const root = document.documentElement;
+      // The final theme should be applied
+      expect(root.style.getPropertyValue("--color-primary")).toBe("#ba68c8");
+      vi.useRealTimers();
+    });
+  });
+
+  describe("Invalid Theme Handling", () => {
+    test("invalid mood is rejected at boundary", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // Set a valid theme first
+      act(() => {
+        wsController.simulateThemeChange("calm");
+      });
+
+      const root = document.documentElement;
+      const colorBefore = root.style.getPropertyValue("--color-primary");
+
+      // Try to send an invalid mood (this goes through raw receiveMessage)
+      act(() => {
+        wsController.receiveMessage({
+          type: "theme_change",
+          payload: {
+            mood: "invalid-mood" as ThemeMood,
+            genre: "sci-fi",
+            region: "city",
+            backgroundUrl: null,
+          },
+        });
+      });
+
+      // Theme should not have changed (Zod validation rejects it)
+      expect(root.style.getPropertyValue("--color-primary")).toBe(colorBefore);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+  });
+
+  describe("Theme During Interaction", () => {
+    test("theme remains stable during player_input cycle", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const { wsController } = renderGameView();
+
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // Set initial theme
+      act(() => {
+        wsController.simulateThemeChange("mysterious");
+      });
+
+      const root = document.documentElement;
+      const initialColor = root.style.getPropertyValue("--color-primary");
+      expect(initialColor).toBe("#00bcd4");
+
+      vi.useRealTimers();
+
+      // User types input (this requires real timers)
+      const user = userEvent.setup();
+      const input = screen.getByPlaceholderText("What do you do?");
+      await user.type(input, "test{Enter}");
+
+      // Theme should remain the same
+      expect(root.style.getPropertyValue("--color-primary")).toBe(initialColor);
+    });
+
+    test("input remains available during theme transition", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      // Change theme with long transition
+      act(() => {
+        wsController.simulateThemeChange("ominous", {
+          transitionDuration: 3000,
+        });
+      });
+
+      // Input should still be available during transition
+      const input = screen.getByPlaceholderText("What do you do?");
+      expect(input).not.toBeDisabled();
+      vi.useRealTimers();
+    });
+  });
+
+  describe("Custom Transition Duration", () => {
+    test("custom transitionDuration is respected", () => {
+      vi.useFakeTimers();
+      const { wsController } = renderGameView();
+
+      act(() => {
+        vi.advanceTimersByTime(1100);
+      });
+
+      act(() => {
+        wsController.simulateAuthentication();
+      });
+
+      act(() => {
+        wsController.simulateThemeChange("triumphant", {
+          transitionDuration: 5000,
+        });
+      });
+
+      // Theme should be applied
+      const root = document.documentElement;
+      expect(root.style.getPropertyValue("--color-primary")).toBe("#b8860b");
+      vi.useRealTimers();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add comprehensive Vitest integration tests that verify WebSocket message flows through the frontend component tree
- Fill the gap between isolated unit tests (mock everything) and full E2E tests (slow browser tests)
- Add Playwright E2E test file for browser-level testing (E2E infrastructure needs investigation, see #126)

## Test Coverage (47 new tests)

| File | Tests | Description |
|------|-------|-------------|
| `helpers/test-utils.tsx` | - | MockWebSocketController and render helpers |
| `message-flows.test.tsx` | 19 | Connection, player input, GM streaming, edge cases |
| `streaming-narrative.test.tsx` | 8 | Progressive display, auto-scroll, rapid chunks |
| `error-handling.test.tsx` | 11 | Error display and recovery |
| `theme-integration.test.tsx` | 9 | CSS variables, debouncing, invalid mood handling |

## Changes to Existing Files

- `frontend/src/App.tsx`: Export `GameView` and `AdventureSession` for testing
- `e2e/playwright.config.ts`: Fix `npm` → `bun` for project consistency

## Test plan

- [x] All 149 frontend tests pass
- [x] TypeScript compilation passes
- [x] ESLint passes
- [ ] E2E tests (blocked by #126)

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)