### PR TITLE
fix(history-compactor): fix summary generation and add continuity

### DIFF
--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -39,7 +39,7 @@ export interface EnvConfig {
   compactionCharThreshold: number;
   /** Number of entries to retain after compaction (default 20) */
   retainedEntryCount: number;
-  /** Model to use for summarization (default "claude-haiku-3") */
+  /** Model to use for summarization (default "claude-3-5-haiku-latest") */
   compactionSummaryModel: string;
 }
 
@@ -285,7 +285,7 @@ export function validateEnvironment(rawEnv: RawEnv = process.env): ValidationRes
     // History compaction
     compactionCharThreshold,
     retainedEntryCount,
-    compactionSummaryModel: rawEnv.COMPACTION_SUMMARY_MODEL || "claude-haiku-3",
+    compactionSummaryModel: rawEnv.COMPACTION_SUMMARY_MODEL || "claude-3-5-haiku-latest",
   };
 
   return { errors, warnings, config };

--- a/backend/tests/unit/env.test.ts
+++ b/backend/tests/unit/env.test.ts
@@ -313,7 +313,7 @@ describe("validateEnvironment", () => {
       replicateApiToken: "r8_abc123",
       compactionCharThreshold: 100000,
       retainedEntryCount: 20,
-      compactionSummaryModel: "claude-haiku-3",
+      compactionSummaryModel: "claude-3-5-haiku-latest",
     });
   });
 

--- a/backend/tests/unit/history-compactor.test.ts
+++ b/backend/tests/unit/history-compactor.test.ts
@@ -223,4 +223,28 @@ describe("HistoryCompactor", () => {
       expect(result.archivePath).toMatch(/history\/\d{4}-\d{2}-\d{2}-\d{6}\.md$/);
     });
   });
+
+  describe("summary continuity", () => {
+    test("incorporates previous summary in new summary", async () => {
+      // First compaction - no previous summary
+      const history1 = createTestHistory(30);
+      const result1 = await compactor.compact(history1);
+
+      expect(result1.success).toBe(true);
+      expect(result1.summary?.text).toBeDefined();
+
+      // Second compaction - with previous summary
+      const history2 = {
+        entries: createTestHistory(30).entries,
+        summary: result1.summary!, // Use the summary from first compaction
+      };
+
+      const result2 = await compactor.compact(history2);
+
+      expect(result2.success).toBe(true);
+      expect(result2.summary?.text).toBeDefined();
+      // Mock summary should include reference to previous summary
+      expect(result2.summary?.text).toContain("Previous summary incorporated");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fixed invalid model name (`claude-haiku-3` → `claude-3-5-haiku-latest`)
- Fixed Agent SDK system prompt to prevent model from trying to use tools
- Fixed error logging to properly serialize Error objects
- Added summary continuity - subsequent compactions now incorporate previous summaries

## Problem

History compaction was running but failing to generate summaries. Logs showed:
```
{"error":{},"msg":"Failed to generate summary, proceeding without"}
{"hasSummary":false,"msg":"History compaction completed"}
```

The error serialized as `{}` because Error objects have non-enumerable properties.

## Root Causes

1. **Invalid model name** - `"claude-haiku-3"` is not a valid SDK model identifier
2. **Weak system prompt** - Agent SDK context confused the model into trying to use tools instead of directly writing the summary
3. **Poor error logging** - Error objects weren't being serialized properly
4. **Missing continuity** - Second compaction would lose the first summary (A→B lost when creating B→C)

## Changes

| File | Change |
|------|--------|
| `backend/src/env.ts` | Fixed default model to `claude-3-5-haiku-latest` |
| `backend/src/services/history-compactor.ts` | Fixed prompt, error logging, added continuity |
| `backend/tests/unit/env.test.ts` | Updated test expectation |
| `backend/tests/unit/history-compactor.test.ts` | Added continuity test |

## Test plan

- [x] All 422 unit tests pass
- [x] Verified summarization works with test script
- [x] Pre-commit hooks pass (typecheck, lint, tests)

🤖 Generated with [Claude Code](https://claude.ai/code)