### PR TITLE
fix(paths): resolve paths relative to backend root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,15 +100,20 @@ Catalog-first strategy: `ImageCatalogService` searches `/assets/backgrounds` bef
 
 **Backend**:
 - `PORT` (default 3000)
-- `ADVENTURES_DIR` (default ./adventures)
+- `ADVENTURES_DIR` (default `{backend}/adventures`) - Adventure save data directory
+- `STATIC_ROOT` (default `{project}/frontend/dist`) - Frontend static files
+- `LOGS_DIR` (default `{backend}/logs`) - Log file output directory
+- `BACKGROUNDS_DIR` (default `{backend}/assets/backgrounds`) - Background images directory
 - `REPLICATE_API_TOKEN` (required for image generation)
 - `MOCK_SDK` (set "true" for testing without Agent SDK)
 - `ALLOWED_ORIGINS` (comma-separated list, defaults to `http://localhost:5173,http://localhost:3000`)
 - `LOG_LEVEL` (default "info") - Set log verbosity: "debug", "info", "warn", "error"
-- `LOG_FILE` (default enabled) - Set to "false" to disable rotating file logs in `backend/logs/`
+- `LOG_FILE` (default enabled) - Set to "false" to disable rotating file logs
 - `NODE_ENV` (default unset) - Set to "production" for JSON log output, otherwise uses pretty format
 - `MAX_CONNECTIONS` (default 100) - Maximum concurrent WebSocket connections
 - `INPUT_TIMEOUT` (default 60000) - Timeout in milliseconds for input processing (minimum 1000ms)
+
+Note: All path defaults are computed as absolute paths at startup, so the server works correctly regardless of the current working directory.
 
 ## Critical Dependencies
 

--- a/backend/src/adventure-state.ts
+++ b/backend/src/adventure-state.ts
@@ -25,8 +25,8 @@ export class AdventureStateManager {
   private history: NarrativeHistory = { entries: [] };
 
   constructor(adventuresDir?: string) {
-    // Use environment variable for consistency between server and tests
-    this.adventuresDir = adventuresDir ?? process.env.ADVENTURES_DIR ?? "./adventures";
+    // Use validated env config for default path (absolute, computed at startup)
+    this.adventuresDir = adventuresDir ?? env.adventuresDir;
   }
 
   /**

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -17,6 +17,7 @@
  */
 
 import { logger } from "./logger";
+import { DEFAULT_PATHS } from "./paths";
 
 /**
  * Validated environment configuration
@@ -32,6 +33,8 @@ export interface EnvConfig {
   logFile: boolean;
   nodeEnv: string | undefined;
   staticRoot: string;
+  logsDir: string;
+  backgroundsDir: string;
   mockSdk: boolean;
   replicateApiToken: string | undefined;
   // History compaction settings
@@ -164,6 +167,8 @@ export interface RawEnv {
   LOG_FILE?: string;
   NODE_ENV?: string;
   STATIC_ROOT?: string;
+  LOGS_DIR?: string;
+  BACKGROUNDS_DIR?: string;
   MOCK_SDK?: string;
   REPLICATE_API_TOKEN?: string;
   // History compaction
@@ -272,14 +277,16 @@ export function validateEnvironment(rawEnv: RawEnv = process.env): ValidationRes
   const config: EnvConfig = {
     port,
     host: rawEnv.HOST || "localhost",
-    adventuresDir: rawEnv.ADVENTURES_DIR || "./adventures",
+    adventuresDir: rawEnv.ADVENTURES_DIR || DEFAULT_PATHS.adventures,
     allowedOrigins: parseAllowedOrigins(rawEnv.ALLOWED_ORIGINS),
     maxConnections,
     inputTimeout,
     logLevel,
     logFile: rawEnv.LOG_FILE !== "false",
     nodeEnv: rawEnv.NODE_ENV,
-    staticRoot: rawEnv.STATIC_ROOT || "../frontend/dist",
+    staticRoot: rawEnv.STATIC_ROOT || DEFAULT_PATHS.staticRoot,
+    logsDir: rawEnv.LOGS_DIR || DEFAULT_PATHS.logs,
+    backgroundsDir: rawEnv.BACKGROUNDS_DIR || DEFAULT_PATHS.backgrounds,
     mockSdk: parseBoolean(rawEnv.MOCK_SDK, false),
     replicateApiToken,
     // History compaction

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -11,10 +11,14 @@
  */
 
 import pino from "pino";
+import { join } from "node:path";
+import { DEFAULT_PATHS } from "./paths";
 
 const level = process.env.LOG_LEVEL || "info";
 const isProduction = process.env.NODE_ENV === "production";
 const enableFileLogging = process.env.LOG_FILE !== "false";
+// Compute logs directory before env.ts is loaded (logger runs first due to import order)
+const logsDir = process.env.LOGS_DIR || DEFAULT_PATHS.logs;
 
 /**
  * Build pino transport configuration.
@@ -33,11 +37,11 @@ function buildTransport(): pino.TransportSingleOptions | pino.TransportMultiOpti
           options: { destination: 1 }, // stdout
           level,
         },
-        // Rotating file logs in ./logs/
+        // Rotating file logs
         {
           target: "pino-roll",
           options: {
-            file: "./logs/app",
+            file: join(logsDir, "app"),
             frequency: "daily",
             size: "10m",
             mkdir: true,

--- a/backend/src/paths.ts
+++ b/backend/src/paths.ts
@@ -1,0 +1,52 @@
+/**
+ * Path Resolution Module
+ *
+ * Computes absolute paths for all default directories to ensure the server
+ * works correctly regardless of the current working directory.
+ *
+ * Uses import.meta.dirname (Bun-native) to determine the backend root,
+ * then resolves all paths relative to that.
+ */
+
+import { resolve } from "node:path";
+
+/**
+ * Backend root directory (where package.json lives).
+ * Computed from this file's location: backend/src/paths.ts -> backend/
+ */
+export const BACKEND_ROOT = resolve(import.meta.dirname, "..");
+
+/**
+ * Resolve a path relative to the backend root directory.
+ *
+ * @param segments - Path segments to join and resolve
+ * @returns Absolute path
+ *
+ * @example
+ * resolveFromBackend("logs") // => "/path/to/backend/logs"
+ * resolveFromBackend("assets", "backgrounds") // => "/path/to/backend/assets/backgrounds"
+ */
+export function resolveFromBackend(...segments: string[]): string {
+  return resolve(BACKEND_ROOT, ...segments);
+}
+
+/**
+ * Default paths for all configurable directories.
+ * These are absolute paths computed at startup.
+ *
+ * Each can be overridden via environment variable:
+ * - adventures: ADVENTURES_DIR
+ * - logs: LOGS_DIR
+ * - backgrounds: BACKGROUNDS_DIR
+ * - staticRoot: STATIC_ROOT
+ */
+export const DEFAULT_PATHS = {
+  /** Adventure save data directory */
+  adventures: resolveFromBackend("adventures"),
+  /** Log file output directory */
+  logs: resolveFromBackend("logs"),
+  /** Background images directory (for catalog and generation) */
+  backgrounds: resolveFromBackend("assets", "backgrounds"),
+  /** Frontend static files (Vite build output) */
+  staticRoot: resolveFromBackend("..", "frontend", "dist"),
+} as const;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,7 @@
 
 import { Hono } from "hono";
 import { logger, createRequestLogger } from "./logger";
+import { env } from "./env";
 import { createBunWebSocket } from "hono/bun";
 import { serveStatic } from "hono/bun";
 import type { WSContext } from "hono/ws";
@@ -51,8 +52,8 @@ const { upgradeWebSocket, websocket } = createBunWebSocket();
 // Initialize Hono app
 const app = new Hono();
 
-// Adventures directory - configurable via environment for testing
-const ADVENTURES_DIR = process.env.ADVENTURES_DIR || "./adventures";
+// Adventures directory - uses validated env config
+const ADVENTURES_DIR = env.adventuresDir;
 
 // Allowed origins for WebSocket CSRF protection
 // Configurable via comma-separated ALLOWED_ORIGINS env var
@@ -655,13 +656,12 @@ async function validateAndLoadAdventure(
   logger.debug({ adventureId, mood: theme.mood }, "Sent stored theme");
 }
 
-// Serve static frontend files from ../frontend/dist
-// This serves the built Vite React app
-const STATIC_ROOT = process.env.STATIC_ROOT || "../frontend/dist";
+// Serve static frontend files - uses validated env config
+const STATIC_ROOT = env.staticRoot;
 
-// Serve background images from ./assets/backgrounds at /backgrounds/*
+// Serve background images at /backgrounds/*
 // This must come before SPA fallback to avoid conflicts
-app.use("/backgrounds/*", serveStatic({ root: "./assets/backgrounds", rewriteRequestPath: (path) => path.replace(/^\/backgrounds/, "") }));
+app.use("/backgrounds/*", serveStatic({ root: env.backgroundsDir, rewriteRequestPath: (path) => path.replace(/^\/backgrounds/, "") }));
 
 // Serve static assets (JS, CSS, images, etc.)
 app.use("/assets/*", serveStatic({ root: STATIC_ROOT }));

--- a/backend/src/services/image-catalog.ts
+++ b/backend/src/services/image-catalog.ts
@@ -14,11 +14,12 @@
 import { Glob } from "bun";
 import { existsSync } from "fs";
 import type { ThemeMood, Genre, Region } from "../../../shared/protocol";
+import { DEFAULT_PATHS } from "../paths";
 
 /**
- * Default backgrounds directory (relative to backend root)
+ * Default backgrounds directory (absolute path computed at startup)
  */
-const DEFAULT_BACKGROUNDS_DIR = "./assets/backgrounds";
+const DEFAULT_BACKGROUNDS_DIR = DEFAULT_PATHS.backgrounds;
 
 /**
  * Service for finding background images by mood/genre/region using directory glob patterns.

--- a/backend/src/services/image-generator.ts
+++ b/backend/src/services/image-generator.ts
@@ -21,13 +21,14 @@ import { resolve } from "path";
 import { existsSync, mkdirSync } from "fs";
 import type { ThemeMood, Genre, Region } from "../../../shared/protocol";
 import { logger } from "../logger";
+import { DEFAULT_PATHS } from "../paths";
 
 /**
  * Default configuration for image generation
  */
 const DEFAULT_CONFIG = {
   /** Directory where generated images are saved (must match server static route) */
-  outputDirectory: "./assets/backgrounds",
+  outputDirectory: DEFAULT_PATHS.backgrounds,
   /** Timeout for image generation in milliseconds (30 seconds) */
   timeout: 30000,
   /** Maximum number of generations allowed per session */

--- a/backend/tests/unit/env.test.ts
+++ b/backend/tests/unit/env.test.ts
@@ -244,8 +244,16 @@ describe("validateEnvironment", () => {
     expect(result.config.logLevel).toBe("info");
     expect(result.config.logFile).toBe(true);
     expect(result.config.mockSdk).toBe(false);
-    expect(result.config.adventuresDir).toBe("./adventures");
-    expect(result.config.staticRoot).toBe("../frontend/dist");
+    // Default paths are now absolute (computed from backend root)
+    expect(result.config.adventuresDir).toMatch(/\/adventures$/);
+    expect(result.config.staticRoot).toMatch(/\/frontend\/dist$/);
+    expect(result.config.logsDir).toMatch(/\/logs$/);
+    expect(result.config.backgroundsDir).toMatch(/\/assets\/backgrounds$/);
+    // All default paths should be absolute (start with /)
+    expect(result.config.adventuresDir).toMatch(/^\//);
+    expect(result.config.staticRoot).toMatch(/^\//);
+    expect(result.config.logsDir).toMatch(/^\//);
+    expect(result.config.backgroundsDir).toMatch(/^\//);
   });
 
   test("warns when REPLICATE_API_TOKEN is missing", () => {
@@ -292,6 +300,8 @@ describe("validateEnvironment", () => {
       LOG_FILE: "false",
       NODE_ENV: "production",
       STATIC_ROOT: "/var/www/static",
+      LOGS_DIR: "/var/log/adventure",
+      BACKGROUNDS_DIR: "/var/data/backgrounds",
       MOCK_SDK: "true",
       REPLICATE_API_TOKEN: "r8_abc123",
     });
@@ -309,6 +319,8 @@ describe("validateEnvironment", () => {
       logFile: false,
       nodeEnv: "production",
       staticRoot: "/var/www/static",
+      logsDir: "/var/log/adventure",
+      backgroundsDir: "/var/data/backgrounds",
       mockSdk: true,
       replicateApiToken: "r8_abc123",
       compactionCharThreshold: 100000,
@@ -324,7 +336,8 @@ describe("validateEnvironment", () => {
 
     expect(result.config.port).toBe(3000);
     expect(result.config.host).toBe("localhost");
-    expect(result.config.adventuresDir).toBe("./adventures");
+    // Default paths are now absolute
+    expect(result.config.adventuresDir).toMatch(/\/adventures$/);
     expect(result.config.allowedOrigins).toEqual([
       "http://localhost:5173",
       "http://localhost:3000",
@@ -334,7 +347,9 @@ describe("validateEnvironment", () => {
     expect(result.config.logLevel).toBe("info");
     expect(result.config.logFile).toBe(true);
     expect(result.config.nodeEnv).toBeUndefined();
-    expect(result.config.staticRoot).toBe("../frontend/dist");
+    expect(result.config.staticRoot).toMatch(/\/frontend\/dist$/);
+    expect(result.config.logsDir).toMatch(/\/logs$/);
+    expect(result.config.backgroundsDir).toMatch(/\/assets\/backgrounds$/);
     expect(result.config.mockSdk).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- Server now works correctly regardless of the current working directory
- All path defaults are computed as absolute paths at startup using `import.meta.dirname`
- Add new `paths.ts` module to centralize path computation
- Add `LOGS_DIR` and `BACKGROUNDS_DIR` environment variables for configurability

## Changes

| File | Change |
|------|--------|
| `backend/src/paths.ts` | New module computing `BACKEND_ROOT` and `DEFAULT_PATHS` |
| `backend/src/env.ts` | Add `logsDir`, `backgroundsDir` fields; use computed defaults |
| `backend/src/logger.ts` | Use computed logs directory |
| `backend/src/server.ts` | Use env config for all paths |
| `backend/src/adventure-state.ts` | Use `env.adventuresDir` |
| `backend/src/services/image-*.ts` | Use `DEFAULT_PATHS.backgrounds` |
| `backend/tests/unit/env.test.ts` | Updated to expect absolute paths |
| `CLAUDE.md` | Document new env vars |

## Test plan

- [x] All 475 unit tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes
- [ ] Manual test: Run server from project root directory
- [ ] Manual test: Run server from backend directory

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)