### PR TITLE
feat(server): add graceful shutdown handling (#43)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,8 +2,13 @@
 // Starts the Bun server with HTTP and WebSocket support
 
 import { env, validateEnv } from "./env";
-import server from "./server";
+import server, {
+  heartbeatInterval,
+  imageGeneratorService,
+  drainConnections,
+} from "./server";
 import { logger } from "./logger";
+import { initializeShutdown } from "./shutdown";
 
 // Validate environment variables before starting server
 // Fails fast with clear error message if configuration is invalid
@@ -14,11 +19,19 @@ const HOST = env.host;
 
 logger.info({ host: HOST, port: PORT }, "Starting Adventure Engine Backend");
 
-Bun.serve({
+const bunServer = Bun.serve({
   port: PORT,
   hostname: HOST,
   fetch: server.fetch,
   websocket: server.websocket,
+});
+
+// Initialize graceful shutdown handlers
+initializeShutdown({
+  server: bunServer,
+  heartbeatInterval,
+  imageGeneratorService,
+  drainConnections,
 });
 
 logger.info({ url: `http://${HOST}:${PORT}`, wsEndpoint: `ws://${HOST}:${PORT}/ws` }, "Server running");

--- a/backend/src/shutdown.ts
+++ b/backend/src/shutdown.ts
@@ -1,0 +1,92 @@
+/**
+ * Graceful Shutdown Module
+ *
+ * Handles SIGTERM and SIGINT signals to cleanly shut down the server.
+ * Ensures all resources are properly released before exit.
+ */
+
+import { logger } from "./logger";
+
+/**
+ * Dependencies required for graceful shutdown
+ */
+export interface ShutdownDeps {
+  server: { stop(closeActiveConnections?: boolean): void };
+  heartbeatInterval: ReturnType<typeof setInterval>;
+  imageGeneratorService: { close(): void };
+  drainConnections: (reason: string) => void;
+}
+
+let isShuttingDown = false;
+let deps: ShutdownDeps | null = null;
+
+/**
+ * Initialize graceful shutdown handlers.
+ * Should be called once after server starts.
+ * @param d Services and server instance to clean up
+ */
+export function initializeShutdown(d: ShutdownDeps): void {
+  deps = d;
+  process.on("SIGTERM", () => void handleShutdown("SIGTERM"));
+  process.on("SIGINT", () => void handleShutdown("SIGINT"));
+  logger.info("Graceful shutdown handlers registered");
+}
+
+/**
+ * Handle shutdown signal.
+ * Cleans up resources and exits.
+ */
+async function handleShutdown(signal: string): Promise<void> {
+  // Prevent multiple shutdown attempts
+  if (isShuttingDown) {
+    logger.warn({ signal }, "Shutdown already in progress, ignoring signal");
+    return;
+  }
+
+  isShuttingDown = true;
+  const startTime = Date.now();
+
+  logger.info({ signal }, "Graceful shutdown initiated");
+
+  if (!deps) {
+    logger.error("Shutdown dependencies not initialized");
+    process.exit(1);
+  }
+
+  try {
+    // Step 1: Stop accepting new connections
+    logger.debug("Stopping server listener");
+    deps.server.stop(false);
+
+    // Step 2: Clear heartbeat interval
+    logger.debug("Clearing heartbeat interval");
+    clearInterval(deps.heartbeatInterval);
+
+    // Step 3: Drain WebSocket connections with shutdown message
+    logger.debug("Draining WebSocket connections");
+    deps.drainConnections("Server shutting down");
+
+    // Step 4: Close image generator service
+    logger.debug("Closing image generator service");
+    deps.imageGeneratorService.close();
+
+    // Step 5: Allow time for log buffers to flush
+    await new Promise((r) => setTimeout(r, 100));
+
+    const elapsed = Date.now() - startTime;
+    logger.info({ elapsed, signal }, "Graceful shutdown complete");
+
+    process.exit(0);
+  } catch (err) {
+    logger.error({ err }, "Error during shutdown");
+    process.exit(1);
+  }
+}
+
+/**
+ * Check if shutdown is in progress.
+ * Can be used by other modules to reject new work during shutdown.
+ */
+export function isShutdownInProgress(): boolean {
+  return isShuttingDown;
+}

--- a/backend/tests/unit/shutdown.test.ts
+++ b/backend/tests/unit/shutdown.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for graceful shutdown module
+ */
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+
+describe("Shutdown Module", () => {
+  // Mock dependencies
+  const createMockDeps = () => ({
+    server: {
+      stop: mock(() => {}),
+    },
+    heartbeatInterval: setInterval(() => {}, 10000),
+    imageGeneratorService: {
+      close: mock(() => {}),
+    },
+    drainConnections: mock(() => {}),
+  });
+
+  beforeEach(() => {
+    // Note: shutdown.ts has module-level state (isShuttingDown, deps) that cannot
+    // be easily reset between tests in Bun. Tests in this file verify:
+    // - Export availability and types
+    // - Interface compliance
+    // - Initial state (isShutdownInProgress returns false before any shutdown)
+    //
+    // Tests do NOT trigger actual shutdown (which calls process.exit) to avoid
+    // test isolation issues and process termination.
+  });
+
+  describe("initializeShutdown", () => {
+    test("registers signal handlers without error", async () => {
+      // Fresh import to get clean module state
+      const { initializeShutdown } = await import("../../src/shutdown");
+      const deps = createMockDeps();
+
+      expect(() => {
+        initializeShutdown(deps as Parameters<typeof initializeShutdown>[0]);
+      }).not.toThrow();
+
+      // Clean up interval
+      clearInterval(deps.heartbeatInterval);
+    });
+  });
+
+  describe("isShutdownInProgress", () => {
+    test("returns false before shutdown is initiated", async () => {
+      const { isShutdownInProgress } = await import("../../src/shutdown");
+
+      // Initial state should be false
+      expect(isShutdownInProgress()).toBe(false);
+    });
+  });
+
+  describe("ShutdownDeps interface", () => {
+    test("mock deps satisfy interface requirements", () => {
+      const deps = createMockDeps();
+
+      // Verify mock structure matches expected interface
+      expect(typeof deps.server.stop).toBe("function");
+      expect(typeof deps.imageGeneratorService.close).toBe("function");
+      expect(typeof deps.drainConnections).toBe("function");
+      expect(deps.heartbeatInterval).toBeDefined();
+
+      // Clean up
+      clearInterval(deps.heartbeatInterval);
+    });
+  });
+});
+
+describe("drainConnections function (from server.ts)", () => {
+  test("drainConnections is exported from server", async () => {
+    const { drainConnections } = await import("../../src/server");
+
+    expect(typeof drainConnections).toBe("function");
+  });
+
+  test("drainConnections handles empty connections map", async () => {
+    const { drainConnections, connections } = await import("../../src/server");
+
+    // Ensure connections is empty
+    connections.clear();
+
+    // Should not throw when there are no connections
+    expect(() => {
+      drainConnections("Test shutdown");
+    }).not.toThrow();
+  });
+});
+
+describe("heartbeatInterval export (from server.ts)", () => {
+  test("heartbeatInterval is exported from server", async () => {
+    const { heartbeatInterval } = await import("../../src/server");
+
+    expect(heartbeatInterval).toBeDefined();
+    // It should be a Timer/Interval object
+    expect(typeof heartbeatInterval).toBe("object");
+  });
+});
+
+describe("imageGeneratorService export (from server.ts)", () => {
+  test("imageGeneratorService is exported from server", async () => {
+    const { imageGeneratorService } = await import("../../src/server");
+
+    expect(imageGeneratorService).toBeDefined();
+    expect(typeof imageGeneratorService.close).toBe("function");
+  });
+
+  test("imageGeneratorService.close can be called without error", async () => {
+    const { imageGeneratorService } = await import("../../src/server");
+
+    // Should not throw when called
+    expect(() => {
+      imageGeneratorService.close();
+    }).not.toThrow();
+  });
+});

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -15,6 +15,7 @@ export const ErrorCodeSchema = z.enum([
   "GM_ERROR",
   "STATE_CORRUPTED",
   "PROCESSING_TIMEOUT",
+  "SERVER_SHUTDOWN",
 ]);
 
 export type ErrorCode = z.infer<typeof ErrorCodeSchema>;


### PR DESCRIPTION
## Summary

- Add signal handlers for SIGTERM and SIGINT to cleanly shut down the server
- Send `SERVER_SHUTDOWN` error message to connected WebSocket clients before closing
- Clear heartbeat monitoring interval
- Close image generator service
- Use WebSocket close code 1012 (Service Restart) for proper client reconnection

Closes #43

## Test plan

- [x] All unit tests pass (430 tests)
- [x] TypeScript type check passes
- [x] ESLint passes
- [ ] Manual test: Start server, connect client, send `kill -TERM <pid>` and verify clean shutdown with client notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)