### PR TITLE
fix(error-handler): improve timeout message accuracy

### DIFF
--- a/backend/src/error-handler.ts
+++ b/backend/src/error-handler.ts
@@ -148,7 +148,7 @@ export function mapProcessingTimeoutError(error: ProcessingTimeoutError): ErrorD
     code: "PROCESSING_TIMEOUT",
     message: error.message,
     retryable: true,
-    userMessage: "The game master is taking too long. Please try again.",
+    userMessage: "The game master is taking longer than expected. Your response may still arrive shortly.",
     technicalDetails: `Input processing timed out after ${error.timeoutMs}ms`,
     originalError: error,
   };

--- a/backend/tests/unit/error-handler.test.ts
+++ b/backend/tests/unit/error-handler.test.ts
@@ -196,7 +196,7 @@ describe("Error Handler", () => {
       expect(result.code).toBe("PROCESSING_TIMEOUT");
       expect(result.retryable).toBe(true);
       expect(result.userMessage).toBe(
-        "The game master is taking too long. Please try again."
+        "The game master is taking longer than expected. Your response may still arrive shortly."
       );
       expect(result.technicalDetails).toContain("60000ms");
       expect(result.originalError).toBe(error);
@@ -375,7 +375,7 @@ describe("Error Handler", () => {
       const error = new ProcessingTimeoutError(60000);
       const details = mapProcessingTimeoutError(error);
       expect(details.userMessage).toBe(
-        "The game master is taking too long. Please try again."
+        "The game master is taking longer than expected. Your response may still arrive shortly."
       );
       expect(details.retryable).toBe(true);
     });


### PR DESCRIPTION
## Summary
- Updated timeout error message from "Please try again" to "Your response may still arrive shortly"
- The previous message was misleading because the underlying request continues after timeout and the response does eventually arrive

Closes #136

## Test plan
- [x] Unit tests updated and passing
- [x] TypeScript compiles without errors
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)