### PR TITLE
feat(gm-prompt): add player-configurable XP style preference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Token: Sent via `authenticate` message after connection (not in URL for security
 - `./locations.md` - Known places
 - `./quests.md` - Active quests
 
-**MCP Tools**: Only `set_theme` remains (sends WebSocket messages for UI theme updates).
+**MCP Tools**: `set_theme` (UI theme updates) and `set_xp_style` (player XP preference - frequent/milestone/combat-plus).
 
 **Dice Rolling**: The `dice-roller` skill (in corvran plugin) provides a bash script for dice expressions. The GM invokes the skill which handles paths via `${CLAUDE_PLUGIN_ROOT}` - no copying required.
 

--- a/backend/src/adventure-state.ts
+++ b/backend/src/adventure-state.ts
@@ -4,7 +4,7 @@
 import { mkdir, writeFile, readFile, rename, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
-import type { NarrativeEntry } from "../../shared/protocol";
+import type { NarrativeEntry, XpStyle } from "../../shared/protocol";
 import type {
   AdventureState,
   NarrativeHistory,
@@ -408,6 +408,19 @@ export class AdventureStateManager {
     }
 
     this.state.currentTheme = { mood, genre, region, backgroundUrl };
+    await this.save();
+  }
+
+  /**
+   * Update player's XP award style preference
+   * @param xpStyle The player's chosen XP style
+   */
+  async updateXpStyle(xpStyle: XpStyle): Promise<void> {
+    if (!this.state) {
+      throw new Error("No state loaded - call create() or load() first");
+    }
+
+    this.state.playerCharacter.xpStyle = xpStyle;
     await this.save();
   }
 

--- a/backend/src/types/protocol.ts
+++ b/backend/src/types/protocol.ts
@@ -12,6 +12,7 @@ export type {
   PlayerCharacter,
   NPC,
   CombatState,
+  XpStyle,
 } from "../../../shared/protocol";
 
 export {

--- a/backend/tests/unit/adventure-state.test.ts
+++ b/backend/tests/unit/adventure-state.test.ts
@@ -734,4 +734,61 @@ describe("AdventureStateManager", () => {
       expect(adventureDir).toBe(resolve(TEST_ADVENTURES_DIR, state.id));
     });
   });
+
+  describe("updateXpStyle()", () => {
+    test("updates xpStyle to frequent", async () => {
+      await manager.create();
+
+      await manager.updateXpStyle("frequent");
+
+      const state = manager.getState();
+      expect(state?.playerCharacter.xpStyle).toBe("frequent");
+    });
+
+    test("updates xpStyle to milestone", async () => {
+      await manager.create();
+
+      await manager.updateXpStyle("milestone");
+
+      const state = manager.getState();
+      expect(state?.playerCharacter.xpStyle).toBe("milestone");
+    });
+
+    test("updates xpStyle to combat-plus", async () => {
+      await manager.create();
+
+      await manager.updateXpStyle("combat-plus");
+
+      const state = manager.getState();
+      expect(state?.playerCharacter.xpStyle).toBe("combat-plus");
+    });
+
+    test("persists xpStyle to disk", async () => {
+      const state = await manager.create();
+
+      await manager.updateXpStyle("milestone");
+
+      // Reload and verify
+      const newManager = new AdventureStateManager(TEST_ADVENTURES_DIR);
+      const result = await newManager.load(state.id, state.sessionToken);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.state.playerCharacter.xpStyle).toBe("milestone");
+      }
+    });
+
+    test("throws error when no state loaded", async () => {
+      const freshManager = new AdventureStateManager(TEST_ADVENTURES_DIR);
+
+      let errorThrown = false;
+      try {
+        await freshManager.updateXpStyle("frequent");
+      } catch (error) {
+        errorThrown = true;
+        expect((error as Error).message).toContain("No state loaded");
+      }
+      expect(errorThrown).toBe(true);
+    });
+  });
 });

--- a/backend/tests/unit/gm-prompt.test.ts
+++ b/backend/tests/unit/gm-prompt.test.ts
@@ -204,4 +204,71 @@ describe("buildGMSystemPrompt", () => {
       expect(prompt).toContain("never /tmp/");
     });
   });
+
+  describe("XP guidance", () => {
+    test("prompts player for XP preference when xpStyle is undefined", () => {
+      const state = createTestState();
+      // xpStyle is undefined by default
+      const prompt = buildGMSystemPrompt(state);
+
+      expect(prompt).toContain("XP PREFERENCE (not yet set)");
+      expect(prompt).toContain("ask the player how they prefer XP to be awarded");
+      expect(prompt).toContain("Frequent");
+      expect(prompt).toContain("Milestone");
+      expect(prompt).toContain("Combat-plus");
+      expect(prompt).toContain("set_xp_style");
+    });
+
+    test("includes frequent style guidance when xpStyle is frequent", () => {
+      const state = createTestState({
+        playerCharacter: {
+          name: "Test Hero",
+          attributes: {},
+          xpStyle: "frequent",
+        },
+      });
+      const prompt = buildGMSystemPrompt(state);
+
+      expect(prompt).toContain("XP AWARDS (Frequent Style)");
+      expect(prompt).toContain("Award XP immediately when earned");
+      expect(prompt).toContain("Exploration: 25-50 XP");
+      expect(prompt).toContain("Roleplay: 25 XP");
+      expect(prompt).toContain("Creativity: 25-50 XP");
+      expect(prompt).not.toContain("XP PREFERENCE (not yet set)");
+    });
+
+    test("includes milestone style guidance when xpStyle is milestone", () => {
+      const state = createTestState({
+        playerCharacter: {
+          name: "Test Hero",
+          attributes: {},
+          xpStyle: "milestone",
+        },
+      });
+      const prompt = buildGMSystemPrompt(state);
+
+      expect(prompt).toContain("XP AWARDS (Milestone Style)");
+      expect(prompt).toContain("Award XP at natural story beats");
+      expect(prompt).toContain("Quest completion: 100-300 XP");
+      expect(prompt).toContain("narrative summary");
+      expect(prompt).not.toContain("XP PREFERENCE (not yet set)");
+    });
+
+    test("includes combat-plus style guidance when xpStyle is combat-plus", () => {
+      const state = createTestState({
+        playerCharacter: {
+          name: "Test Hero",
+          attributes: {},
+          xpStyle: "combat-plus",
+        },
+      });
+      const prompt = buildGMSystemPrompt(state);
+
+      expect(prompt).toContain("XP AWARDS (Combat-Plus Style)");
+      expect(prompt).toContain("Always award NPC Reward XP");
+      expect(prompt).toContain("Exceptional moments");
+      expect(prompt).toContain("rare and meaningful");
+      expect(prompt).not.toContain("XP PREFERENCE (not yet set)");
+    });
+  });
 });

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -379,6 +379,15 @@ export const SystemDefinitionSchema = z.object({
 export type SystemDefinition = z.infer<typeof SystemDefinitionSchema>;
 
 /**
+ * XP award style preference.
+ * - frequent: Award XP for every notable action (combat, exploration, roleplay, clever solutions)
+ * - milestone: Award XP at story beats (quest completion, major discoveries, significant encounters)
+ * - combat-plus: Always award combat XP, plus occasional bonuses for exceptional creativity
+ */
+export const XpStyleSchema = z.enum(["frequent", "milestone", "combat-plus"]);
+export type XpStyle = z.infer<typeof XpStyleSchema>;
+
+/**
  * Extended player character type with RPG properties.
  * Backward compatible - all RPG fields are optional.
  */
@@ -396,6 +405,7 @@ export const PlayerCharacterSchema = z.object({
   inventory: z.array(InventoryItemSchema).optional(),
   xp: z.number().optional(),
   level: z.number().optional(),
+  xpStyle: XpStyleSchema.optional(),
 });
 
 export type PlayerCharacter = z.infer<typeof PlayerCharacterSchema>;


### PR DESCRIPTION
## Summary
- Adds `set_xp_style` MCP tool for player XP preference (frequent/milestone/combat-plus)
- GM asks player preference early in adventure when `xpStyle` is undefined
- Choice persists to `state.json` via new `updateXpStyle()` method
- GM prompt includes style-specific XP guidance based on player's choice

## Test plan
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] 442 unit tests pass (12 new tests added)
- [ ] Manual test: Start adventure, verify GM asks XP preference
- [ ] Manual test: Choose style, verify GM follows that style consistently

Closes #138

🤖 Generated with [Claude Code](https://claude.ai/code)