### PR TITLE
feat(ui): add tool status bar for real-time feedback

### DIFF
--- a/backend/tests/unit/protocol.test.ts
+++ b/backend/tests/unit/protocol.test.ts
@@ -420,6 +420,83 @@ describe("parseServerMessage()", () => {
     });
   });
 
+  describe("tool_status message", () => {
+    test("accepts valid tool_status with active state", () => {
+      const result = parseServerMessage({
+        type: "tool_status",
+        payload: {
+          state: "active",
+          description: "Setting the scene...",
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success && result.data.type === "tool_status") {
+        expect(result.data.payload.state).toBe("active");
+        expect(result.data.payload.description).toBe("Setting the scene...");
+      }
+    });
+
+    test("accepts valid tool_status with idle state", () => {
+      const result = parseServerMessage({
+        type: "tool_status",
+        payload: {
+          state: "idle",
+          description: "Ready",
+        },
+      });
+      expect(result.success).toBe(true);
+      if (result.success && result.data.type === "tool_status") {
+        expect(result.data.payload.state).toBe("idle");
+        expect(result.data.payload.description).toBe("Ready");
+      }
+    });
+
+    test("rejects tool_status with invalid state", () => {
+      const result = parseServerMessage({
+        type: "tool_status",
+        payload: {
+          state: "processing",
+          description: "Working...",
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test("rejects tool_status without description", () => {
+      const result = parseServerMessage({
+        type: "tool_status",
+        payload: {
+          state: "active",
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test("rejects tool_status without state", () => {
+      const result = parseServerMessage({
+        type: "tool_status",
+        payload: {
+          description: "Thinking...",
+        },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    test("accepts all valid states", () => {
+      const validStates = ["active", "idle"];
+      for (const state of validStates) {
+        const result = parseServerMessage({
+          type: "tool_status",
+          payload: {
+            state,
+            description: "Test description",
+          },
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+  });
+
   describe("invalid messages", () => {
     test("rejects unknown message type", () => {
       const result = parseServerMessage({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import {
   NarrativeLog,
   InputField,
   ConnectionStatus,
+  ToolStatusBar,
 } from "./components";
 import { BackgroundLayer } from "./components/BackgroundLayer";
 import { useWebSocket } from "./hooks/useWebSocket";
@@ -58,6 +59,10 @@ export function GameView({
     useState<StreamingMessage | null>(null);
   const [isGMResponding, setIsGMResponding] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [toolStatus, setToolStatus] = useState<{
+    state: "active" | "idle";
+    description: string;
+  }>({ state: "idle", description: "Ready" });
 
   const handleMessage = useCallback((message: ServerMessage) => {
     switch (message.type) {
@@ -112,6 +117,13 @@ export function GameView({
       case "error":
         setError(message.payload.message);
         setIsGMResponding(false);
+        break;
+
+      case "tool_status":
+        setToolStatus({
+          state: message.payload.state,
+          description: message.payload.description,
+        });
         break;
 
       case "pong":
@@ -192,6 +204,8 @@ export function GameView({
           isStreaming={streamingMessage !== null}
           summary={historySummary}
         />
+
+        <ToolStatusBar state={toolStatus.state} description={toolStatus.description} />
 
         <div className="game-input-container">
           <InputField

--- a/frontend/src/components/ToolStatusBar.css
+++ b/frontend/src/components/ToolStatusBar.css
@@ -1,0 +1,57 @@
+/* ToolStatusBar styles */
+
+.tool-status-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-sm);
+  min-height: 28px;
+  flex-shrink: 0;
+}
+
+.tool-status-bar--active {
+  color: var(--color-primary);
+}
+
+.tool-status-bar--idle {
+  color: var(--color-text-muted);
+}
+
+.tool-status-bar__indicator {
+  display: flex;
+  gap: 3px;
+}
+
+.tool-status-bar__dot {
+  width: 6px;
+  height: 6px;
+  background-color: var(--color-primary);
+  border-radius: 50%;
+  animation: toolStatusPulse 1.4s ease-in-out infinite;
+}
+
+.tool-status-bar__dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.tool-status-bar__dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes toolStatusPulse {
+  0%,
+  80%,
+  100% {
+    opacity: 0.4;
+    transform: scale(0.8);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.tool-status-bar__text {
+  font-style: italic;
+}

--- a/frontend/src/components/ToolStatusBar.tsx
+++ b/frontend/src/components/ToolStatusBar.tsx
@@ -1,0 +1,30 @@
+import "./ToolStatusBar.css";
+
+export interface ToolStatusBarProps {
+  state: "active" | "idle";
+  description: string;
+}
+
+/**
+ * Status bar displaying vague descriptions of tool activity.
+ * Shows animated dots when active, static text when idle.
+ */
+export function ToolStatusBar({ state, description }: ToolStatusBarProps) {
+  return (
+    <div
+      className={`tool-status-bar tool-status-bar--${state}`}
+      role="status"
+      aria-live="polite"
+      data-testid="tool-status-bar"
+    >
+      {state === "active" && (
+        <span className="tool-status-bar__indicator" aria-hidden="true">
+          <span className="tool-status-bar__dot"></span>
+          <span className="tool-status-bar__dot"></span>
+          <span className="tool-status-bar__dot"></span>
+        </span>
+      )}
+      <span className="tool-status-bar__text">{description}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -8,3 +8,5 @@ export { InputField } from "./InputField";
 export type { InputFieldProps } from "./InputField";
 export { NarrativeEntry } from "./NarrativeEntry";
 export { NarrativeLog } from "./NarrativeLog";
+export { ToolStatusBar } from "./ToolStatusBar";
+export type { ToolStatusBarProps } from "./ToolStatusBar";

--- a/frontend/tests/unit/ToolStatusBar.test.tsx
+++ b/frontend/tests/unit/ToolStatusBar.test.tsx
@@ -1,0 +1,107 @@
+import { describe, test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ToolStatusBar } from "../../src/components/ToolStatusBar";
+
+describe("ToolStatusBar", () => {
+  describe("rendering", () => {
+    test("renders with idle state", () => {
+      render(<ToolStatusBar state="idle" description="Ready" />);
+      expect(screen.getByText("Ready")).toBeInTheDocument();
+      expect(screen.getByTestId("tool-status-bar")).toHaveClass(
+        "tool-status-bar--idle"
+      );
+    });
+
+    test("renders with active state", () => {
+      render(
+        <ToolStatusBar state="active" description="Setting the scene..." />
+      );
+      expect(screen.getByText("Setting the scene...")).toBeInTheDocument();
+      expect(screen.getByTestId("tool-status-bar")).toHaveClass(
+        "tool-status-bar--active"
+      );
+    });
+
+    test("shows animated dots when active", () => {
+      render(<ToolStatusBar state="active" description="Thinking..." />);
+      const indicator = screen.getByTestId("tool-status-bar").querySelector(
+        ".tool-status-bar__indicator"
+      );
+      expect(indicator).toBeInTheDocument();
+      const dots = indicator?.querySelectorAll(".tool-status-bar__dot");
+      expect(dots).toHaveLength(3);
+    });
+
+    test("hides animated dots when idle", () => {
+      render(<ToolStatusBar state="idle" description="Ready" />);
+      const indicator = screen.getByTestId("tool-status-bar").querySelector(
+        ".tool-status-bar__indicator"
+      );
+      expect(indicator).not.toBeInTheDocument();
+    });
+
+    test("displays different descriptions correctly", () => {
+      const { rerender } = render(
+        <ToolStatusBar state="active" description="Consulting the dice..." />
+      );
+      expect(screen.getByText("Consulting the dice...")).toBeInTheDocument();
+
+      rerender(
+        <ToolStatusBar state="active" description="Updating world state..." />
+      );
+      expect(screen.getByText("Updating world state...")).toBeInTheDocument();
+    });
+  });
+
+  describe("accessibility", () => {
+    test("has role=status for screen readers", () => {
+      render(<ToolStatusBar state="idle" description="Ready" />);
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+
+    test("has aria-live=polite for announcements", () => {
+      render(<ToolStatusBar state="active" description="Working..." />);
+      expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+    });
+
+    test("indicator has aria-hidden=true", () => {
+      render(<ToolStatusBar state="active" description="Working..." />);
+      const indicator = screen.getByTestId("tool-status-bar").querySelector(
+        ".tool-status-bar__indicator"
+      );
+      expect(indicator).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  describe("state transitions", () => {
+    test("transitions from idle to active", () => {
+      const { rerender } = render(
+        <ToolStatusBar state="idle" description="Ready" />
+      );
+      expect(screen.getByTestId("tool-status-bar")).toHaveClass(
+        "tool-status-bar--idle"
+      );
+
+      rerender(
+        <ToolStatusBar state="active" description="Setting the scene..." />
+      );
+      expect(screen.getByTestId("tool-status-bar")).toHaveClass(
+        "tool-status-bar--active"
+      );
+    });
+
+    test("transitions from active to idle", () => {
+      const { rerender } = render(
+        <ToolStatusBar state="active" description="Thinking..." />
+      );
+      expect(screen.getByTestId("tool-status-bar")).toHaveClass(
+        "tool-status-bar--active"
+      );
+
+      rerender(<ToolStatusBar state="idle" description="Ready" />);
+      expect(screen.getByTestId("tool-status-bar")).toHaveClass(
+        "tool-status-bar--idle"
+      );
+    });
+  });
+});

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -255,6 +255,31 @@ export const ThemeChangeMessageSchema = z.object({
   payload: ThemeChangePayloadSchema,
 });
 
+// ========================
+// Tool Status Types
+// ========================
+
+/**
+ * Tool status states for the status bar display.
+ * - active: A tool is currently being used
+ * - idle: No tool activity, ready for input
+ */
+export const ToolStatusStateSchema = z.enum(["active", "idle"]);
+export type ToolStatusState = z.infer<typeof ToolStatusStateSchema>;
+
+/**
+ * Tool status message for real-time feedback on tool activity.
+ * Displays vague descriptions to inform users without exposing GM internals.
+ */
+export const ToolStatusMessageSchema = z.object({
+  type: z.literal("tool_status"),
+  payload: z.object({
+    state: ToolStatusStateSchema,
+    /** User-friendly description (e.g., "Setting the scene...", "Ready") */
+    description: z.string(),
+  }),
+});
+
 export const ServerMessageSchema = z.discriminatedUnion("type", [
   GMResponseStartMessageSchema,
   GMResponseChunkMessageSchema,
@@ -263,6 +288,7 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
   ErrorMessageSchema,
   PongMessageSchema,
   ThemeChangeMessageSchema,
+  ToolStatusMessageSchema,
 ]);
 
 export type ServerMessage = z.infer<typeof ServerMessageSchema>;


### PR DESCRIPTION
## Summary

- Adds a persistent 1-line status bar between the narrative window and player input
- Displays vague descriptions of tool activity during GM response (e.g., "Setting the scene...", "Consulting the dice...")
- Shows animated indicator when active, "Ready" when idle
- Uses WebSocket `tool_status` messages for real-time updates

Closes #140

## Changes

### Protocol (`shared/protocol.ts`)
- Added `ToolStatusStateSchema` (active/idle)
- Added `ToolStatusMessageSchema` to `ServerMessageSchema` union

### Backend (`backend/src/game-session.ts`)
- Added `getToolDescription()` to map internal tool names to user-friendly text
- Sends `tool_status` (active) when tool_use blocks detected
- Sends `tool_status` (idle) after `gm_response_end`

### Frontend
- Created `ToolStatusBar` component with animated dots indicator
- Integrated between `NarrativeLog` and `InputField` in `App.tsx`

### Tests
- Protocol validation tests for `tool_status` message
- Component tests for `ToolStatusBar` (rendering, accessibility, transitions)
- Updated game-session tests for new message sequence

## Test plan

- [x] Backend typecheck passes
- [x] Backend lint passes  
- [x] Backend unit tests pass (448 tests)
- [x] Frontend typecheck passes
- [x] Frontend lint passes
- [x] Frontend unit tests pass (159 tests)
- [ ] Manual test: Start adventure, verify status bar shows "Ready"
- [ ] Manual test: Send input, verify status shows tool activity during response
- [ ] Manual test: Verify status returns to "Ready" after response completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)