### PR TITLE
fix(env): validate HOST IP availability at startup

### DIFF
--- a/backend/tests/unit/env.test.ts
+++ b/backend/tests/unit/env.test.ts
@@ -362,16 +362,47 @@ describe("validateEnvironment", () => {
     expect(result.config.logFile).toBe(false);
   });
 
-  test("continues parsing after validation errors", () => {
-    // Even if PORT is invalid, other values should still be parsed
+  test("HOST validation accepts localhost", () => {
     const result = validateEnvironment({
-      PORT: "invalid",
-      HOST: "myhost",
+      HOST: "localhost",
+      REPLICATE_API_TOKEN: "token",
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.config.host).toBe("localhost");
+  });
+
+  test("HOST validation accepts 0.0.0.0", () => {
+    const result = validateEnvironment({
+      HOST: "0.0.0.0",
+      REPLICATE_API_TOKEN: "token",
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.config.host).toBe("0.0.0.0");
+  });
+
+  test("HOST validation rejects unavailable IP", () => {
+    const result = validateEnvironment({
+      HOST: "192.168.99.99",
       REPLICATE_API_TOKEN: "token",
     });
 
     expect(result.errors).toHaveLength(1);
-    expect(result.config.host).toBe("myhost");
+    expect(result.errors[0]).toContain("192.168.99.99");
+    expect(result.errors[0]).toContain("not available on any network interface");
+  });
+
+  test("continues parsing after validation errors", () => {
+    // Even if PORT is invalid, other values should still be parsed
+    const result = validateEnvironment({
+      PORT: "invalid",
+      HOST: "localhost",
+      REPLICATE_API_TOKEN: "token",
+    });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.config.host).toBe("localhost");
     expect(result.config.replicateApiToken).toBe("token");
   });
 });


### PR DESCRIPTION
## Summary

- Add `validateHost()` to check that HOST IP exists on a network interface before `Bun.serve()` attempts to bind
- Server now fails fast with a clear error instead of hanging indefinitely when HOST IP is unavailable
- Lists available IPs in the error message to help users fix their configuration

## Problem

When `Bun.serve()` tries to bind to an IP address that doesn't exist on any network interface (e.g., ethernet cable unplugged), it hangs indefinitely rather than failing. This made debugging configuration issues difficult.

## Solution

Query `os.networkInterfaces()` at startup to validate the HOST IP is available. Special values (`localhost`, `127.0.0.1`, `0.0.0.0`, `::`, `::1`) bypass this check.

Example error when validation fails:
```
HOST "192.168.99.99" is not available on any network interface. 
Available IPs: 127.0.0.1, ::1, 192.168.141.25, ... 
Use "localhost", "0.0.0.0", or a valid interface IP.
```

## Test plan

- [x] Unit tests for HOST validation (localhost, 0.0.0.0, invalid IP)
- [x] Manual test: `HOST=192.168.99.99 bun run start` fails immediately with clear error
- [x] All existing tests pass (451 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)