### PR TITLE
feat(ui): convert player input to 3-line textarea

### DIFF
--- a/frontend/src/components/InputField.css
+++ b/frontend/src/components/InputField.css
@@ -2,6 +2,7 @@
 
 .input-field {
   display: flex;
+  align-items: flex-start;
   gap: var(--spacing-sm);
 }
 
@@ -18,6 +19,7 @@
   border-radius: var(--radius-sm);
   outline: none;
   transition: border-color 0.2s, background-color 0.2s, color 0.2s;
+  resize: none;
 }
 
 .input-field__input::placeholder {

--- a/frontend/src/components/InputField.tsx
+++ b/frontend/src/components/InputField.tsx
@@ -1,4 +1,9 @@
-import { useState, useCallback, type FormEvent, type KeyboardEvent } from "react";
+import {
+  useState,
+  useCallback,
+  type FormEvent,
+  type KeyboardEvent,
+} from "react";
 import "./InputField.css";
 
 export interface InputFieldProps {
@@ -31,7 +36,7 @@ export function InputField({
   );
 
   const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         handleSubmit();
@@ -42,14 +47,14 @@ export function InputField({
 
   return (
     <form onSubmit={handleFormSubmit} className="input-field">
-      <input
-        type="text"
+      <textarea
         value={value}
         onChange={(e) => setValue(e.target.value)}
         onKeyDown={handleKeyDown}
         disabled={disabled}
         placeholder={placeholder}
         className="input-field__input"
+        rows={3}
       />
       <button
         type="submit"

--- a/frontend/tests/unit/InputField.test.tsx
+++ b/frontend/tests/unit/InputField.test.tsx
@@ -65,6 +65,18 @@ describe("InputField", () => {
       expect(onSubmit).toHaveBeenCalledWith("go north");
     });
 
+    test("Shift+Enter adds newline instead of submitting", async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+      render(<InputField onSubmit={onSubmit} />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "line one{Shift>}{Enter}{/Shift}line two");
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(input).toHaveValue("line one\nline two");
+    });
+
     test("does not submit whitespace-only input", async () => {
       const user = userEvent.setup();
       const onSubmit = vi.fn();


### PR DESCRIPTION
## Summary

- Converts single-line `<input>` to 3-line `<textarea>` for player commands
- Enter submits, Shift+Enter adds newlines
- Textarea scrolls when content exceeds visible lines

Closes #151

## Test plan

- [x] All 11 InputField tests pass (including new Shift+Enter test)
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [ ] Manual test: type multi-line input with Shift+Enter
- [ ] Manual test: verify Enter submits the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)