### PR TITLE
fix: auto-create player/world directories at exact saved slug (#142)

### DIFF
--- a/backend/src/game-session.ts
+++ b/backend/src/game-session.ts
@@ -191,20 +191,16 @@ export class GameSession {
     this.worldManager = new WorldManager(projectDir);
 
     // Auto-create missing ref directories if refs are set but directories don't exist (TD-5)
+    // Uses createAtSlug() to preserve the exact slug from the saved state
     const state = this.stateManager.getState();
     if (state) {
       // Check playerRef
       if (state.playerRef) {
         const playerSlug = state.playerRef.replace(/^players\//, "");
         if (!this.playerManager.exists(playerSlug)) {
-          logger.info({ playerRef: state.playerRef }, "Auto-creating missing player directory from ref");
+          logger.info({ playerRef: state.playerRef, playerSlug }, "Auto-creating missing player directory from ref");
           try {
-            // Extract name from slug (convert kael-thouls to Kael Thouls)
-            const displayName = playerSlug
-              .split("-")
-              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-              .join(" ");
-            await this.playerManager.create(displayName);
+            await this.playerManager.createAtSlug(playerSlug);
           } catch (error) {
             logger.error({ err: error, playerRef: state.playerRef }, "Failed to auto-create player directory");
             // Continue anyway - GM will handle missing files
@@ -216,14 +212,9 @@ export class GameSession {
       if (state.worldRef) {
         const worldSlug = state.worldRef.replace(/^worlds\//, "");
         if (!(await this.worldManager.exists(worldSlug))) {
-          logger.info({ worldRef: state.worldRef }, "Auto-creating missing world directory from ref");
+          logger.info({ worldRef: state.worldRef, worldSlug }, "Auto-creating missing world directory from ref");
           try {
-            // Extract name from slug
-            const displayName = worldSlug
-              .split("-")
-              .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-              .join(" ");
-            await this.worldManager.create(displayName);
+            await this.worldManager.createAtSlug(worldSlug);
           } catch (error) {
             logger.error({ err: error, worldRef: state.worldRef }, "Failed to auto-create world directory");
             // Continue anyway - GM will handle missing files


### PR DESCRIPTION
## Summary

- Fixes bug where loading existing adventures created duplicate directories with `-2` suffix
- Adds `createAtSlug()` method to PlayerManager and WorldManager for creating directories at exact slugs without collision detection
- Updates `GameSession.initialize()` to use `createAtSlug()` for auto-creation from saved refs

## Problem

When loading an adventure with `playerRef: "players/dwig"`, the auto-creation logic was calling `create(displayName)` which triggers collision detection. If `players/dwig/` already existed (or the slug was derived), it would create `players/dwig-2/` instead.

## Solution

Added `createAtSlug(slug)` method that creates directories at the exact specified slug without any collision detection or slug modification. This is appropriate for restoring from saved state where the exact slug must be preserved.

## Test plan

- [x] Unit tests for `PlayerManager.createAtSlug()` (5 tests)
- [x] Unit tests for `WorldManager.createAtSlug()` (9 tests)
- [x] All 666 unit tests pass
- [x] Lint passes
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)