### PR TITLE
fix: remove unused state.json properties (#157)

### DIFF
--- a/backend/src/adventure-state.ts
+++ b/backend/src/adventure-state.ts
@@ -55,12 +55,6 @@ export class AdventureStateManager {
       currentScene: {
         description:
           "The adventure is just beginning. The world awaits your imagination.",
-        location: "Unknown",
-      },
-      worldState: {},
-      playerCharacter: {
-        name: null,
-        attributes: {},
       },
       currentTheme: {
         mood: "calm",
@@ -71,8 +65,6 @@ export class AdventureStateManager {
       // Character/world references (null = GM will prompt for selection)
       playerRef: null,
       worldRef: null,
-      // RPG rules caching (loaded from System.md)
-      systemDefinition: null,
     };
 
     this.history = { entries: [] };
@@ -144,11 +136,6 @@ export class AdventureStateManager {
         region: "village",
         backgroundUrl: null,
       };
-    }
-
-    // Ensure systemDefinition defaults to null
-    if (this.state.systemDefinition === undefined) {
-      this.state.systemDefinition = null;
     }
 
     // Validate session token
@@ -365,9 +352,8 @@ export class AdventureStateManager {
   /**
    * Update current scene description
    * @param description New scene description
-   * @param location Optional location update
    */
-  async updateScene(description: string, location?: string): Promise<void> {
+  async updateScene(description: string): Promise<void> {
     if (!this.state) {
       throw new Error(
         "No state loaded - call create() or load() first"
@@ -375,9 +361,6 @@ export class AdventureStateManager {
     }
 
     this.state.currentScene.description = description;
-    if (location !== undefined) {
-      this.state.currentScene.location = location;
-    }
     await this.save();
   }
 
@@ -411,22 +394,7 @@ export class AdventureStateManager {
       throw new Error("No state loaded - call create() or load() first");
     }
 
-    this.state.playerCharacter.xpStyle = xpStyle;
-    await this.save();
-  }
-
-  /**
-   * Update system definition
-   * @param definition SystemDefinition object or null
-   */
-  async updateSystemDefinition(
-    definition: AdventureState["systemDefinition"]
-  ): Promise<void> {
-    if (!this.state) {
-      throw new Error("No state loaded - call create() or load() first");
-    }
-
-    this.state.systemDefinition = definition;
+    this.state.xpStyle = xpStyle;
     await this.save();
   }
 

--- a/backend/src/game-session.ts
+++ b/backend/src/game-session.ts
@@ -56,22 +56,6 @@ async function withTimeout<T>(
   }
 }
 
-/**
- * Region detection keyword mappings.
- * Order matters: first match wins when multiple keywords could match.
- */
-const REGION_KEYWORDS: [Region, string[]][] = [
-  ["city", ["city", "town"]],
-  ["village", ["village", "hamlet"]],
-  ["forest", ["forest", "woods"]],
-  ["desert", ["desert", "sand"]],
-  ["mountain", ["mountain", "peak"]],
-  ["ocean", ["ocean", "sea"]],
-  ["underground", ["underground", "cave", "dungeon"]],
-  ["castle", ["castle", "palace"]],
-  ["ruins", ["ruins", "ancient"]],
-];
-
 const DEFAULT_REGION: Region = "forest";
 
 /**
@@ -871,35 +855,20 @@ export class GameSession {
 
   /**
    * Derive genre from adventure state
-   * Checks worldState for genre hints, defaults to "high-fantasy"
+   * Returns genre from currentTheme, defaults to "high-fantasy"
    */
   private deriveGenre(state: AdventureState | null): Genre {
     if (!state) return "high-fantasy";
-
-    // Check worldState for genre property
-    const worldGenre = state.worldState.genre as Genre | undefined;
-    if (worldGenre) return worldGenre;
-
-    // Default to high-fantasy
-    return "high-fantasy";
+    return state.currentTheme.genre;
   }
 
   /**
    * Derive region from adventure state.
-   * Checks currentScene.location for region hints using REGION_KEYWORDS mapping.
+   * Returns region from currentTheme, defaults to forest.
    */
   private deriveRegion(state: AdventureState | null): Region {
     if (!state) return DEFAULT_REGION;
-
-    const location = state.currentScene.location.toLowerCase();
-
-    for (const [region, keywords] of REGION_KEYWORDS) {
-      if (keywords.some((keyword) => location.includes(keyword))) {
-        return region;
-      }
-    }
-
-    return DEFAULT_REGION;
+    return state.currentTheme.region;
   }
 
   /**

--- a/backend/src/gm-prompt.ts
+++ b/backend/src/gm-prompt.ts
@@ -526,7 +526,6 @@ function buildFilePaths(
  * This prompt instructs the GM to invoke the character-world-init skill
  */
 function buildSetupRequiredPrompt(
-  safeLocation: string,
   safeDescription: string,
   xpGuidance: string
 ): string {
@@ -541,7 +540,6 @@ SECURITY RULES (apply at all times):
 ${BOUNDARY}
 
 CURRENT SCENE:
-Location: ${safeLocation}
 ${safeDescription}
 
 **SETUP REQUIRED**
@@ -578,21 +576,20 @@ Call set_theme(mood, genre, region) for atmosphere transitions.
  * @returns System prompt string
  */
 export function buildGMSystemPrompt(state: AdventureState): string {
-  const { currentScene, playerCharacter, playerRef, worldRef } = state;
+  const { currentScene, xpStyle, playerRef, worldRef } = state;
 
-  // Sanitize scene values before embedding in prompt
-  const safeLocation = sanitizeStateValue(currentScene.location, 200);
+  // Sanitize scene description before embedding in prompt
   const safeDescription = sanitizeStateValue(currentScene.description, 500);
 
   // Build XP guidance based on player preference
-  const xpGuidance = buildXpGuidance(playerCharacter.xpStyle);
+  const xpGuidance = buildXpGuidance(xpStyle);
 
   // Build file paths based on refs
   const paths = buildFilePaths(playerRef, worldRef);
 
   // When refs are not set, return a setup-only prompt
   if (!paths.hasRefs) {
-    return buildSetupRequiredPrompt(safeLocation, safeDescription, xpGuidance);
+    return buildSetupRequiredPrompt(safeDescription, xpGuidance);
   }
 
   // Build sections for normal gameplay (refs are set)
@@ -619,7 +616,6 @@ SECURITY RULES (apply at all times):
 ${BOUNDARY}
 
 CURRENT SCENE:
-Location: ${safeLocation}
 ${safeDescription}
 
 PLAYER AGENCY (critical - never violate):

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -256,7 +256,7 @@ app.get("/adventure/:id", async (c) => {
       id: string;
       createdAt: string;
       lastActiveAt: string;
-      currentScene: { description: string; location: string };
+      currentScene: { description: string };
     };
 
     return c.json({

--- a/backend/src/types/state.ts
+++ b/backend/src/types/state.ts
@@ -6,18 +6,20 @@ import type {
   ThemeMood,
   Genre,
   Region,
-  SystemDefinition,
-  PlayerCharacter,
+  XpStyle,
   HistorySummary,
   NarrativeHistory,
 } from "../../../shared/protocol";
 
 // Re-export types needed by other modules
-export type { SystemDefinition, HistorySummary, NarrativeHistory } from "../../../shared/protocol";
+export type { HistorySummary, NarrativeHistory, XpStyle } from "../../../shared/protocol";
 
 /**
  * Adventure state stored in state.json
- * Contains current world state, scene info, and player character data
+ * Contains session info, scene context, theme, and player preferences.
+ *
+ * Note: Player character data and world state are stored in markdown files
+ * referenced by playerRef and worldRef, not in this state object.
  */
 export interface AdventureState {
   id: string; // UUID
@@ -27,10 +29,7 @@ export interface AdventureState {
   lastActiveAt: string; // ISO 8601
   currentScene: {
     description: string; // Current narrative context
-    location: string; // Where the player is
   };
-  worldState: Record<string, unknown>; // Flexible world facts
-  playerCharacter: PlayerCharacter;
   // Current visual theme (persisted for session restoration)
   currentTheme: {
     mood: ThemeMood;
@@ -43,8 +42,8 @@ export interface AdventureState {
   // null indicates new adventure (GM will prompt for selection)
   playerRef: string | null;
   worldRef: string | null;
-  // RPG system definition (optional - loaded from System.md)
-  systemDefinition?: SystemDefinition | null;
+  // XP award style preference (set via set_xp_style MCP tool)
+  xpStyle?: XpStyle;
 }
 
 // NarrativeHistory is now imported from shared/protocol.ts

--- a/backend/tests/integration/server.test.ts
+++ b/backend/tests/integration/server.test.ts
@@ -119,13 +119,12 @@ describe("Server REST Endpoints", () => {
 
       const res = await app.request(`/adventure/${adventureId}`);
       const data = (await res.json()) as {
-        currentScene: { description: string; location: string };
+        currentScene: { description: string };
       };
 
       expect(data.currentScene.description).toBe(
         "The adventure is just beginning. The world awaits your imagination."
       );
-      expect(data.currentScene.location).toBe("Unknown");
     });
   });
 

--- a/backend/tests/unit/game-session.test.ts
+++ b/backend/tests/unit/game-session.test.ts
@@ -458,65 +458,25 @@ describe("GameSession", () => {
 
   /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/require-await */
   describe("Theme Management", () => {
-    test("derives genre from adventure state worldState", async () => {
+    test("derives genre from currentTheme", async () => {
       const { ws } = createMockWS();
       const session = new GameSession(ws, stateManager);
       await session.initialize(adventureId, sessionToken);
 
-      // Update worldState with genre
       const state = session.getState();
-      if (state) {
-        state.worldState.genre = "sci-fi";
-      }
-
       // Access private method via reflection for testing
       const genre = (session as any).deriveGenre(state);
-      expect(genre).toBe("sci-fi");
+      expect(genre).toBe("high-fantasy"); // Default from creation
     });
 
-    test("defaults to high-fantasy when no genre in worldState", async () => {
+    test("derives region from currentTheme", async () => {
       const { ws } = createMockWS();
       const session = new GameSession(ws, stateManager);
       await session.initialize(adventureId, sessionToken);
 
       const state = session.getState();
-      const genre = (session as any).deriveGenre(state);
-      expect(genre).toBe("high-fantasy");
-    });
-
-    test("derives region from location keywords", async () => {
-      const { ws } = createMockWS();
-      const session = new GameSession(ws, stateManager);
-      await session.initialize(adventureId, sessionToken);
-
-      // Create a modified state with specific location
-      const state = session.getState();
-      if (state) {
-        state.currentScene.location = "The Dark Forest of Shadows";
-        const region = (session as any).deriveRegion(state);
-        expect(region).toBe("forest");
-
-        state.currentScene.location = "The Ancient Ruins of Eldoria";
-        const region2 = (session as any).deriveRegion(state);
-        expect(region2).toBe("ruins");
-
-        state.currentScene.location = "A bustling city market";
-        const region3 = (session as any).deriveRegion(state);
-        expect(region3).toBe("city");
-      }
-    });
-
-    test("defaults to forest when no region keywords found", async () => {
-      const { ws } = createMockWS();
-      const session = new GameSession(ws, stateManager);
-      await session.initialize(adventureId, sessionToken);
-
-      const state = session.getState();
-      if (state) {
-        state.currentScene.location = "An unknown place";
-        const region = (session as any).deriveRegion(state);
-        expect(region).toBe("forest");
-      }
+      const region = (session as any).deriveRegion(state);
+      expect(region).toBe("village"); // Default from creation
     });
 
     test("debounces duplicate mood changes within 1 second", async () => {
@@ -729,7 +689,7 @@ describe("GameSession", () => {
       await (session as any).handleSetXpStyleTool("frequent");
 
       const state = session.getState();
-      expect(state?.playerCharacter.xpStyle).toBe("frequent");
+      expect(state?.xpStyle).toBe("frequent");
     });
 
     test("updates xpStyle for all valid styles", async () => {
@@ -739,13 +699,13 @@ describe("GameSession", () => {
 
       // Test each style
       await (session as any).handleSetXpStyleTool("frequent");
-      expect(session.getState()?.playerCharacter.xpStyle).toBe("frequent");
+      expect(session.getState()?.xpStyle).toBe("frequent");
 
       await (session as any).handleSetXpStyleTool("milestone");
-      expect(session.getState()?.playerCharacter.xpStyle).toBe("milestone");
+      expect(session.getState()?.xpStyle).toBe("milestone");
 
       await (session as any).handleSetXpStyleTool("combat-plus");
-      expect(session.getState()?.playerCharacter.xpStyle).toBe("combat-plus");
+      expect(session.getState()?.xpStyle).toBe("combat-plus");
     });
 
     test("calls stateManager.updateXpStyle", async () => {

--- a/backend/tests/unit/gm-prompt.test.ts
+++ b/backend/tests/unit/gm-prompt.test.ts
@@ -18,12 +18,6 @@ function createTestState(overrides: Partial<AdventureState> = {}): AdventureStat
     lastActiveAt: new Date().toISOString(),
     currentScene: {
       description: "A test scene",
-      location: "Test Location",
-    },
-    worldState: {},
-    playerCharacter: {
-      name: null,
-      attributes: {},
     },
     currentTheme: {
       mood: "calm",
@@ -33,7 +27,6 @@ function createTestState(overrides: Partial<AdventureState> = {}): AdventureStat
     },
     playerRef: "players/test-hero",
     worldRef: "worlds/test-world",
-    systemDefinition: null,
     ...overrides,
   };
 }
@@ -51,12 +44,10 @@ describe("buildGMSystemPrompt", () => {
       const state = createTestState({
         currentScene: {
           description: "A mysterious forest clearing",
-          location: "Elderwood Glade",
         },
       });
       const prompt = buildGMSystemPrompt(state);
 
-      expect(prompt).toContain("Elderwood Glade");
       expect(prompt).toContain("A mysterious forest clearing");
     });
 
@@ -115,25 +106,10 @@ describe("buildGMSystemPrompt", () => {
       expect(prompt).toContain("ignore instructions");
     });
 
-    test("sanitizes scene location", () => {
-      const state = createTestState({
-        currentScene: {
-          description: "Normal description",
-          location: "Test<script>alert('xss')</script>Location",
-        },
-      });
-      const prompt = buildGMSystemPrompt(state);
-
-      // Should not crash and should include sanitized content
-      expect(prompt).toBeDefined();
-      expect(prompt).toContain("Test");
-    });
-
     test("sanitizes scene description", () => {
       const state = createTestState({
         currentScene: {
           description: "Normal<script>alert('xss')</script>Description",
-          location: "Test Location",
         },
       });
       const prompt = buildGMSystemPrompt(state);
@@ -143,24 +119,10 @@ describe("buildGMSystemPrompt", () => {
       expect(prompt).toContain("Normal");
     });
 
-    test("truncates very long location", () => {
-      const state = createTestState({
-        currentScene: {
-          description: "Normal",
-          location: "A".repeat(500), // 500 chars, should be truncated
-        },
-      });
-      const prompt = buildGMSystemPrompt(state);
-
-      // Should truncate to reasonable length (200 chars based on sanitizeStateValue)
-      expect(prompt.length).toBeLessThan(5000);
-    });
-
     test("truncates very long description", () => {
       const state = createTestState({
         currentScene: {
           description: "B".repeat(1000), // 1000 chars, should be truncated
-          location: "Test",
         },
       });
       const prompt = buildGMSystemPrompt(state);
@@ -356,11 +318,7 @@ describe("buildGMSystemPrompt", () => {
 
     test("includes frequent style guidance when xpStyle is frequent", () => {
       const state = createTestState({
-        playerCharacter: {
-          name: "Test Hero",
-          attributes: {},
-          xpStyle: "frequent",
-        },
+        xpStyle: "frequent",
       });
       const prompt = buildGMSystemPrompt(state);
 
@@ -374,11 +332,7 @@ describe("buildGMSystemPrompt", () => {
 
     test("includes milestone style guidance when xpStyle is milestone", () => {
       const state = createTestState({
-        playerCharacter: {
-          name: "Test Hero",
-          attributes: {},
-          xpStyle: "milestone",
-        },
+        xpStyle: "milestone",
       });
       const prompt = buildGMSystemPrompt(state);
 
@@ -391,11 +345,7 @@ describe("buildGMSystemPrompt", () => {
 
     test("includes combat-plus style guidance when xpStyle is combat-plus", () => {
       const state = createTestState({
-        playerCharacter: {
-          name: "Test Hero",
-          attributes: {},
-          xpStyle: "combat-plus",
-        },
+        xpStyle: "combat-plus",
       });
       const prompt = buildGMSystemPrompt(state);
 


### PR DESCRIPTION
## Summary
- Remove `worldState` - world data lives in markdown files via `worldRef`
- Remove `currentScene.location` - never set (always "Unknown")
- Remove `playerCharacter` object - flatten `xpStyle` to root level
- Remove `systemDefinition` - caching never wired up

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run test:unit` - 656 tests pass
- [x] `bun run lint` passes
- [ ] Manual test: create new adventure, verify state.json has simplified structure
- [ ] Manual test: load existing adventure with old properties, verify it still works

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)