### PR TITLE
feat: increase maxTurns from 20 to 40 for world creation

### DIFF
--- a/backend/src/game-session.ts
+++ b/backend/src/game-session.ts
@@ -782,7 +782,7 @@ export class GameSession {
         includePartialMessages: true, // Enable token streaming
         permissionMode: "acceptEdits", // Auto-accept file edits within sandbox
         model: "claude-sonnet-4-5", // Use latest Sonnet for quality
-        maxTurns: 20, // Allow multiple file reads/writes + response
+        maxTurns: 40, // Allow extensive world creation + narrative
         maxThinkingTokens: 10000, // Allow extensive reasoning
       },
     });


### PR DESCRIPTION
## Summary
Increases the Agent SDK `maxTurns` limit from 20 to 40 to support extensive world creation workflows.

## Problem
The character-world-init skill creates detailed worlds with:
- Character sheet and state files
- World state, locations, NPCs, and quests
- Rich narrative content for each file
- MCP tool calls for character/world selection
- Theme setting and opening narrative

This process can easily require 15-20+ turns when the GM creates high-quality content. The previous 20-turn limit caused world creation to stop mid-process, leaving incomplete files or missing the opening narrative.

Example from production: Created "Tikeldot" (gnome sorcerer) in "Realm of Deceit" (dark low-fantasy) with full character stats, detailed world lore, 3 locations, 6 NPCs, and quest system - but stopped before delivering opening narrative due to turn limit.

## Solution
Increase `maxTurns` to 40 in `backend/src/game-session.ts:785`

This provides:
- 15-20 turns for world creation
- 10+ turns for quality narrative response
- Safety margin for complex interactions

## Testing
✓ All checks passed (typecheck, lint, unit tests)

## Related
- Issue #172: Future user-controlled abort mechanism for additional control

🤖 Generated with [Claude Code](https://claude.com/claude-code)