### PR TITLE
fix: async initialization not awaited for image services

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -104,13 +104,26 @@ const backgroundImageService = new BackgroundImageService(
   }
 );
 
-// Initialize image generator service
-try {
-  imageGeneratorService.initialize();
-} catch (err) {
-  logger.warn({ err }, "Image generator initialization failed");
-  logger.warn("Image generation will be unavailable, catalog/fallback only");
+/**
+ * Initialize image services at startup.
+ * Catalog initialization is required (throws on failure).
+ * Generator initialization is optional (logs warning on failure).
+ */
+async function initializeImageServices(): Promise<void> {
+  // Initialize catalog (required - throws on failure)
+  await imageCatalogService.initialize();
+
+  // Initialize generator (optional - logs warning on failure)
+  try {
+    await imageGeneratorService.initialize();
+  } catch (err) {
+    logger.warn({ err }, "Image generator initialization failed");
+    logger.warn("Image generation will be unavailable, catalog/fallback only");
+  }
 }
+
+// Initialize image services before server starts
+await initializeImageServices();
 
 // Health check (used by launch script to verify server is ready)
 app.get("/api/health", (c) => c.text("Adventure Engine Backend"));

--- a/backend/src/services/image-generator.ts
+++ b/backend/src/services/image-generator.ts
@@ -148,16 +148,20 @@ export class ImageGeneratorService {
    *
    * @throws Error if API token is not set
    */
-  initialize(): void {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async initialize(): Promise<void> {
     if (!this.apiToken) {
       throw new Error(
-        "REPLICATE_API_TOKEN environment variable is required for image generation"
+        "REPLICATE_API_TOKEN environment variable is required for image generation. " +
+          "Set this variable to enable AI-powered background generation, or use catalog-only mode."
       );
     }
 
     this.replicate = new Replicate({
       auth: this.apiToken,
     });
+
+    logger.info("Image generator initialized with Replicate API");
   }
 
   /**

--- a/backend/tests/unit/image-generator.test.ts
+++ b/backend/tests/unit/image-generator.test.ts
@@ -108,34 +108,35 @@ describe("ImageGeneratorService", () => {
   });
 
   describe("initialize()", () => {
-    test("creates Replicate client", () => {
-      service.initialize();
+    test("creates Replicate client", async () => {
+      await service.initialize();
       // If no error thrown, client was created successfully
       expect(true).toBe(true);
     });
 
-    test("throws error if no API token", () => {
+    test("throws error if no API token", async () => {
       const noTokenService = new ImageGeneratorService({
         outputDirectory: TEST_OUTPUT_DIR,
       });
 
-      expect(() => noTokenService.initialize()).toThrow(
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(noTokenService.initialize()).rejects.toThrow(
         "REPLICATE_API_TOKEN environment variable is required"
       );
     });
 
-    test("can be called multiple times safely", () => {
-      service.initialize();
+    test("can be called multiple times safely", async () => {
+      await service.initialize();
       service.close();
-      service.initialize();
+      await service.initialize();
       // If no error thrown, test passes
       expect(true).toBe(true);
     });
   });
 
   describe("generateImage()", () => {
-    beforeEach(() => {
-      service.initialize();
+    beforeEach(async () => {
+      await service.initialize();
     });
 
     test("generates image with mood, genre, and region", async () => {
@@ -325,7 +326,7 @@ describe("ImageGeneratorService", () => {
     });
 
     test("returns correct count after generations", async () => {
-      service.initialize();
+      await service.initialize();
 
       await service.generateImage("calm", "low-fantasy", "forest");
       expect(service.getGenerationCount()).toBe(1);
@@ -341,7 +342,7 @@ describe("ImageGeneratorService", () => {
     });
 
     test("decrements after each generation", async () => {
-      service.initialize();
+      await service.initialize();
 
       await service.generateImage("calm", "low-fantasy", "forest");
       expect(service.getRemainingGenerations()).toBe(2);
@@ -354,7 +355,7 @@ describe("ImageGeneratorService", () => {
     });
 
     test("never goes below 0", async () => {
-      service.initialize();
+      await service.initialize();
 
       // Exhaust limit
       await service.generateImage("calm", "low-fantasy", "forest");
@@ -375,15 +376,15 @@ describe("ImageGeneratorService", () => {
   });
 
   describe("close()", () => {
-    test("clears Replicate client", () => {
-      service.initialize();
+    test("clears Replicate client", async () => {
+      await service.initialize();
       service.close();
       // If no error thrown, test passes
       expect(true).toBe(true);
     });
 
-    test("can be called multiple times safely", () => {
-      service.initialize();
+    test("can be called multiple times safely", async () => {
+      await service.initialize();
       service.close();
       service.close();
       // If no error thrown, test passes
@@ -399,8 +400,8 @@ describe("ImageGeneratorService", () => {
   });
 
   describe("prompt construction", () => {
-    beforeEach(() => {
-      service.initialize();
+    beforeEach(async () => {
+      await service.initialize();
     });
 
     test("includes all mood types correctly", async () => {
@@ -425,7 +426,7 @@ describe("ImageGeneratorService", () => {
           maxGenerationsPerSession: 10,
           apiToken: TEST_API_TOKEN,
         });
-        service.initialize();
+        await service.initialize();
       }
     });
 
@@ -453,7 +454,7 @@ describe("ImageGeneratorService", () => {
           maxGenerationsPerSession: 10,
           apiToken: TEST_API_TOKEN,
         });
-        service.initialize();
+        await service.initialize();
       }
     });
 
@@ -483,7 +484,7 @@ describe("ImageGeneratorService", () => {
           maxGenerationsPerSession: 15,
           apiToken: TEST_API_TOKEN,
         });
-        service.initialize();
+        await service.initialize();
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes #44 - Converts image service initialization from fire-and-forget to proper async/await pattern with validation and error handling.

## Changes

### Core Changes
- **ImageCatalogService**: Added async `initialize()` method that validates backgrounds directory exists and pre-loads file cache
- **ImageGeneratorService**: Converted `initialize()` to async and improved error messaging
- **Server startup**: Created `initializeImageServices()` function with proper async/await orchestration

### Behavior Changes

**Before:**
- Fire-and-forget initialization (no await)
- Catalog lazy-loaded on first theme change
- Silent failures possible
- No validation at startup

**After:**
- Async/await pattern with proper error handling
- Catalog pre-loaded and validated at startup (fail-fast)
- Server fails immediately if backgrounds directory missing
- Server starts gracefully without API token (catalog-only mode)
- Clear logging of initialization status

### Error Handling

**Catalog (Critical):**
- Missing directory → Server fails to start with clear error
- Missing fallback → Log warning, continue

**Generator (Optional):**
- Missing token → Log warning, continue in catalog-only mode
- Server starts normally without API token

## Testing

✅ All 781 tests pass
- Added comprehensive test suite for `ImageCatalogService.initialize()`
  - Succeeds when directory exists
  - Throws when directory missing
  - Pre-loads cache
  - Warns if fallback missing
- Updated all existing tests to use async/await pattern
- All lint and typecheck rules pass

## Documentation

- Updated `CLAUDE.md` with new startup behavior
- Marked `BACKGROUNDS_DIR` as required (directory must exist at startup)
- Marked `REPLICATE_API_TOKEN` as optional (graceful degradation)
- Added "Image Generation" section explaining initialization

## Files Changed

- `backend/src/services/image-catalog.ts` - Add async initialize()
- `backend/src/services/image-generator.ts` - Convert to async
- `backend/src/server.ts` - Orchestrate async initialization
- `backend/tests/unit/image-catalog.test.ts` - Add new tests
- `backend/tests/unit/image-generator.test.ts` - Update for async
- `CLAUDE.md` - Document requirements

## Test Plan

- [x] Server fails with clear error if backgrounds directory missing
- [x] Server starts successfully without REPLICATE_API_TOKEN
- [x] Image catalog pre-loaded at startup (logs file count)
- [x] All unit tests pass (781/781)
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)