### PR TITLE
feat: extract and display Claude's actual error messages

### DIFF
--- a/backend/src/error-handler.ts
+++ b/backend/src/error-handler.ts
@@ -31,8 +31,13 @@ export interface ErrorDetails {
 /**
  * Map SDK error codes to user-friendly error details
  * Implements the error mapping strategy from the spec
+ * @param sdkErrorCode The SDK error code
+ * @param messageContent Optional error message content from Claude (for "unknown" errors)
  */
-export function mapSDKError(sdkErrorCode: SDKAssistantMessageError): ErrorDetails {
+export function mapSDKError(
+  sdkErrorCode: SDKAssistantMessageError,
+  messageContent?: string
+): ErrorDetails {
   const errorMap: Record<
     SDKAssistantMessageError,
     Omit<ErrorDetails, "originalError">
@@ -77,7 +82,9 @@ export function mapSDKError(sdkErrorCode: SDKAssistantMessageError): ErrorDetail
       message: "Unknown error",
       retryable: true,
       userMessage: "Something went wrong. Please try again.",
-      technicalDetails: "Unknown error from Claude API",
+      technicalDetails: messageContent
+        ? `Claude API error: ${messageContent}`
+        : "Unknown error from Claude API",
     },
   };
 
@@ -196,11 +203,13 @@ export function createErrorPayload(details: ErrorDetails): {
   code: ErrorCode;
   message: string;
   retryable: boolean;
+  technicalDetails?: string;
 } {
   return {
     code: details.code,
     message: details.userMessage,
     retryable: details.retryable,
+    technicalDetails: details.technicalDetails,
   };
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,6 +52,7 @@ interface ErrorState {
   code: ErrorCode;
   message: string;
   retryable: boolean;
+  technicalDetails?: string;
 }
 
 export interface GameViewProps {
@@ -139,12 +140,22 @@ export function GameView({
 
       case "error": {
         // Store full error state
-        setError({
+        const errorState = {
           code: message.payload.code,
           message: message.payload.message,
           retryable: message.payload.retryable,
-        });
+          technicalDetails: message.payload.technicalDetails,
+        };
+        setError(errorState);
         setIsGMResponding(false);
+
+        // Log error to console for debugging
+        console.error("[Adventure Engine] Error received:", {
+          code: errorState.code,
+          message: errorState.message,
+          retryable: errorState.retryable,
+          technicalDetails: errorState.technicalDetails,
+        });
 
         // Apply theme based on error severity
         const errorMood: ThemeMood = message.payload.retryable ? "tense" : "ominous";
@@ -247,6 +258,7 @@ export function GameView({
           code={error.code}
           message={error.message}
           retryable={error.retryable}
+          technicalDetails={error.technicalDetails}
           onRetry={handleRetry}
           onDismiss={handleDismissError}
           isRetrying={isGMResponding}

--- a/frontend/src/components/ErrorPanel.tsx
+++ b/frontend/src/components/ErrorPanel.tsx
@@ -5,6 +5,7 @@ interface ErrorPanelProps {
   code: ErrorCode;
   message: string;
   retryable: boolean;
+  technicalDetails?: string;
   onRetry: () => void;
   onDismiss: () => void;
   isRetrying?: boolean;
@@ -14,6 +15,7 @@ export function ErrorPanel({
   code,
   message,
   retryable,
+  technicalDetails,
   onRetry,
   onDismiss,
   isRetrying = false,
@@ -38,7 +40,16 @@ export function ErrorPanel({
 
       <details className="error-panel__details">
         <summary>Technical details</summary>
-        <code className="error-panel__code">Error code: {code}</code>
+        <code className="error-panel__code">
+          Error code: {code}
+          {technicalDetails && (
+            <>
+              <br />
+              <br />
+              {technicalDetails}
+            </>
+          )}
+        </code>
       </details>
 
       <div className="error-panel__actions">

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -303,6 +303,7 @@ export const ErrorMessageSchema = z.object({
     code: ErrorCodeSchema,
     message: z.string(),
     retryable: z.boolean(),
+    technicalDetails: z.string().optional(),
   }),
 });
 


### PR DESCRIPTION
## Summary

When the Agent SDK returns errors with "unknown" error code, extract Claude's actual error message from the response content and display it to users instead of generic "Unknown error" text.

## Changes

**Backend:**
- Extract error message content from SDK assistant messages when errors occur
- Pass message content through `mapSDKError()` for "unknown" error code mapping
- Include `technicalDetails` in error payloads sent to frontend via WebSocket
- Add full error object to processInput error logs for better debugging

**Frontend:**
- Display `technicalDetails` in ErrorPanel's technical details section
- Log errors to browser console with full context for debugging

**Protocol:**
- Add optional `technicalDetails` field to `ErrorMessageSchema`

**Fix:**
- Increase `maxThinkingTokens` from 1000 to 1024 (valid SDK value)

## Impact

This makes SDK errors much more actionable by showing Claude's specific error message (e.g., "maxThinkingTokens must be 1024 or 2048") instead of hiding it in server logs. Users and developers can now see the actual issue directly in the error popup.

## Test Plan

- [x] TypeScript type checking passes (backend, frontend, shared)
- [x] ESLint passes
- [x] Unit tests pass
- [x] Manual testing: Trigger SDK error and verify technical details appear in popup
- [x] Manual testing: Verify error appears in browser console logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)