### PR TITLE
feat: add user-controlled abort mechanism for GM query sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ bun run lint
 
 Frontend and backend communicate via WebSocket. Protocol types are defined in `/shared/protocol.ts` and re-exported by both sides.
 
-**Client → Server**: `authenticate`, `player_input`, `start_adventure`, `ping`
+**Client → Server**: `authenticate`, `player_input`, `start_adventure`, `ping`, `abort`
 **Server → Client**: `gm_response_start/chunk/end` (streaming), `adventure_loaded`, `theme_change`, `error`, `pong`
 
 WebSocket URL: `ws://localhost:3000/ws?adventureId={adventureId}`

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -562,6 +562,32 @@ app.get(
             }
             break;
 
+          case "abort": {
+            // Handle abort request - stop current GM response
+            if (!conn.authenticated) {
+              logger.warn({ connId }, "Abort received before authentication");
+              break;
+            }
+
+            if (!conn.gameSession) {
+              logger.warn({ connId }, "Abort received but no GameSession");
+              break;
+            }
+
+            // Create request-scoped logger for correlation
+            const { logger: abortLogger } = createRequestLogger(connId, conn.adventureId);
+            abortLogger.info("Processing abort request");
+
+            // Call abort on the game session
+            const result = conn.gameSession.abort();
+            if (result.success) {
+              abortLogger.info({ messageId: result.messageId }, "Abort completed");
+            } else {
+              abortLogger.debug("Abort requested but nothing to abort");
+            }
+            break;
+          }
+
           default:
             logger.warn({ connId, messageType: (message as { type: string }).type }, "Unknown message type");
         }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,6 +82,7 @@ export function GameView({
     state: "active" | "idle";
     description: string;
   }>({ state: "idle", description: "Ready" });
+  const [isAborting, setIsAborting] = useState(false);
 
   const handleMessage = useCallback((message: ServerMessage) => {
     switch (message.type) {
@@ -136,6 +137,7 @@ export function GameView({
           return null;
         });
         setIsGMResponding(false);
+        setIsAborting(false); // Reset aborting state
         break;
 
       case "error": {
@@ -219,6 +221,13 @@ export function GameView({
     applyTheme({ mood: previousMood }); // Restore previous theme
   }, [previousMood, applyTheme]);
 
+  const handleAbort = useCallback(() => {
+    if (!isGMResponding || isAborting) return;
+
+    setIsAborting(true);
+    sendMessage({ type: "abort" });
+  }, [isGMResponding, isAborting, sendMessage]);
+
   // Combine history with streaming message for display
   const displayEntries = useMemo(() => {
     if (streamingMessage && streamingMessage.content) {
@@ -287,6 +296,8 @@ export function GameView({
                   ? "Waiting for response..."
                   : "What do you do?"
             }
+            onAbort={isGMResponding ? handleAbort : undefined}
+            isAborting={isAborting}
           />
         </div>
       </main>

--- a/frontend/src/components/InputField.css
+++ b/frontend/src/components/InputField.css
@@ -60,3 +60,15 @@
   background-color: #b0b0b0;
   cursor: not-allowed;
 }
+
+.input-field__button--abort {
+  background-color: #dc3545;
+}
+
+.input-field__button--abort:hover:not(:disabled) {
+  background-color: #c82333;
+}
+
+.input-field__button--abort:disabled {
+  background-color: #6c757d;
+}

--- a/frontend/src/components/InputField.tsx
+++ b/frontend/src/components/InputField.tsx
@@ -10,12 +10,18 @@ export interface InputFieldProps {
   onSubmit: (text: string) => void;
   disabled?: boolean;
   placeholder?: string;
+  /** Callback for abort action - when provided, shows Stop button instead of Send while disabled */
+  onAbort?: () => void;
+  /** Whether an abort is in progress */
+  isAborting?: boolean;
 }
 
 export function InputField({
   onSubmit,
   disabled = false,
   placeholder = "Enter your command...",
+  onAbort,
+  isAborting = false,
 }: InputFieldProps) {
   const [value, setValue] = useState("");
 
@@ -56,13 +62,25 @@ export function InputField({
         className="input-field__input"
         rows={3}
       />
-      <button
-        type="submit"
-        disabled={disabled || !value.trim()}
-        className="input-field__button"
-      >
-        Send
-      </button>
+      {disabled && onAbort ? (
+        <button
+          type="button"
+          onClick={onAbort}
+          disabled={isAborting}
+          className="input-field__button input-field__button--abort"
+          title="Stop the current response"
+        >
+          {isAborting ? "Stopping..." : "Stop"}
+        </button>
+      ) : (
+        <button
+          type="submit"
+          disabled={disabled || !value.trim()}
+          className="input-field__button"
+        >
+          Send
+        </button>
+      )}
     </form>
   );
 }

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -252,11 +252,16 @@ export const PingMessageSchema = z.object({
   type: z.literal("ping"),
 });
 
+export const AbortMessageSchema = z.object({
+  type: z.literal("abort"),
+});
+
 export const ClientMessageSchema = z.discriminatedUnion("type", [
   AuthenticateMessageSchema,
   PlayerInputMessageSchema,
   StartAdventureMessageSchema,
   PingMessageSchema,
+  AbortMessageSchema,
 ]);
 
 export type ClientMessage = z.infer<typeof ClientMessageSchema>;


### PR DESCRIPTION
## Summary

- Add ability for users to interrupt long-running GM responses via a Stop button
- Stop button replaces Send button during response streaming for clean UI
- Partial responses are preserved in history with "[Response interrupted]" marker
- Input queue is cleared on abort to prevent stale inputs

## Changes

**Protocol** (`shared/protocol.ts`):
- Add `abort` message type to client messages

**Backend** (`backend/src/game-session.ts`, `backend/src/server.ts`):
- Track active query with AbortController
- Add `abort()` method that signals abort and clears input queue
- Check abort signal in response streaming loop
- Handle abort messages in WebSocket handler

**Frontend** (`frontend/src/components/InputField.tsx`):
- Add `onAbort`/`isAborting` props to InputField component
- Show Stop button (red) instead of Send when GM is responding

**Tests**:
- Add 3 unit tests for abort functionality

## Test plan

- [x] Backend typecheck passes
- [x] Backend lint passes
- [x] Backend unit tests pass (791 tests)
- [x] Frontend typecheck passes
- [x] Frontend lint passes
- [x] Frontend tests pass (252 tests)
- [ ] Manual test: Start adventure, click Stop during GM response
- [ ] Manual test: Verify partial response saved to history
- [ ] Manual test: Verify input queue cleared after abort

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)