### PR TITLE
feat: add recap button with forceSave before compaction

### DIFF
--- a/backend/src/types/protocol.ts
+++ b/backend/src/types/protocol.ts
@@ -4,6 +4,7 @@ export type {
   ServerMessage,
   ErrorCode,
   NarrativeEntry,
+  HistorySummary,
   ThemeMood,
   Genre,
   Region,

--- a/frontend/src/components/RecapButton.css
+++ b/frontend/src/components/RecapButton.css
@@ -1,0 +1,23 @@
+/* RecapButton styles */
+
+.recap-button {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.recap-button:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.recap-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/RecapButton.tsx
+++ b/frontend/src/components/RecapButton.tsx
@@ -1,0 +1,29 @@
+import "./RecapButton.css";
+
+export interface RecapButtonProps {
+  onRecap: () => void;
+  disabled: boolean;
+  isRecapping: boolean;
+}
+
+/**
+ * Button to trigger a recap of the adventure.
+ * Creates a summary and starts a fresh GM session.
+ */
+export function RecapButton({
+  onRecap,
+  disabled,
+  isRecapping,
+}: RecapButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onRecap}
+      disabled={disabled || isRecapping}
+      className="recap-button"
+      title="Create a recap and get suggestions for what to do next"
+    >
+      {isRecapping ? "Recapping..." : "Recap"}
+    </button>
+  );
+}

--- a/frontend/src/components/RecapConfirmDialog.css
+++ b/frontend/src/components/RecapConfirmDialog.css
@@ -1,0 +1,71 @@
+/* RecapConfirmDialog styles */
+
+.recap-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.recap-confirm-dialog {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-lg);
+  max-width: 400px;
+  width: 90%;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+}
+
+.recap-confirm-title {
+  margin: 0 0 var(--spacing-md) 0;
+  font-size: var(--font-size-xl);
+  color: var(--color-text);
+}
+
+.recap-confirm-message {
+  margin: 0 0 var(--spacing-lg) 0;
+  color: var(--color-text-secondary);
+  line-height: 1.5;
+}
+
+.recap-confirm-actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: flex-end;
+}
+
+.recap-confirm-button {
+  padding: var(--spacing-sm) var(--spacing-lg);
+  font-size: var(--font-size-base);
+  border-radius: var(--radius-sm);
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.recap-confirm-button--cancel {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}
+
+.recap-confirm-button--cancel:hover {
+  background: var(--color-surface-alt);
+}
+
+.recap-confirm-button--confirm {
+  background: var(--color-primary);
+  color: white;
+}
+
+.recap-confirm-button--confirm:hover {
+  filter: brightness(1.1);
+}
+
+.recap-confirm-button--confirm:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/frontend/src/components/RecapConfirmDialog.tsx
+++ b/frontend/src/components/RecapConfirmDialog.tsx
@@ -1,0 +1,78 @@
+import { useCallback, useEffect } from "react";
+import "./RecapConfirmDialog.css";
+
+export interface RecapConfirmDialogProps {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Confirmation dialog for the recap action.
+ * Explains what will happen and asks for user confirmation.
+ */
+export function RecapConfirmDialog({
+  isOpen,
+  onConfirm,
+  onCancel,
+}: RecapConfirmDialogProps) {
+  // Handle Escape key to cancel
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    },
+    [onCancel]
+  );
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen, handleKeyDown]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="recap-confirm-overlay"
+      onClick={onCancel}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="recap-confirm-title"
+    >
+      <div
+        className="recap-confirm-dialog"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="recap-confirm-title" className="recap-confirm-title">
+          Create Recap?
+        </h2>
+        <p className="recap-confirm-message">
+          This will summarize your adventure so far and start a fresh
+          conversation with the GM. The GM will greet you as a returning
+          adventurer and suggest what to do next.
+        </p>
+        <div className="recap-confirm-actions">
+          <button
+            type="button"
+            className="recap-confirm-button recap-confirm-button--cancel"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="recap-confirm-button recap-confirm-button--confirm"
+            onClick={onConfirm}
+            autoFocus
+          >
+            Create Recap
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ToolStatusBar.css
+++ b/frontend/src/components/ToolStatusBar.css
@@ -3,11 +3,18 @@
 .tool-status-bar {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--spacing-sm);
   padding: var(--spacing-sm) var(--spacing-md);
   font-size: var(--font-size-sm);
   min-height: 28px;
   flex-shrink: 0;
+}
+
+.tool-status-bar__status {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
 }
 
 .tool-status-bar--active {

--- a/frontend/src/components/ToolStatusBar.tsx
+++ b/frontend/src/components/ToolStatusBar.tsx
@@ -1,15 +1,29 @@
 import "./ToolStatusBar.css";
+import { RecapButton } from "./RecapButton";
 
 export interface ToolStatusBarProps {
   state: "active" | "idle";
   description: string;
+  /** Handler for recap button click */
+  onRecap?: () => void;
+  /** Whether recap button should be disabled */
+  recapDisabled?: boolean;
+  /** Whether recap is currently in progress */
+  isRecapping?: boolean;
 }
 
 /**
  * Status bar displaying vague descriptions of tool activity.
  * Shows animated dots when active, static text when idle.
+ * Optionally displays a Recap button on the left.
  */
-export function ToolStatusBar({ state, description }: ToolStatusBarProps) {
+export function ToolStatusBar({
+  state,
+  description,
+  onRecap,
+  recapDisabled = false,
+  isRecapping = false,
+}: ToolStatusBarProps) {
   return (
     <div
       className={`tool-status-bar tool-status-bar--${state}`}
@@ -17,14 +31,23 @@ export function ToolStatusBar({ state, description }: ToolStatusBarProps) {
       aria-live="polite"
       data-testid="tool-status-bar"
     >
-      {state === "active" && (
-        <span className="tool-status-bar__indicator" aria-hidden="true">
-          <span className="tool-status-bar__dot"></span>
-          <span className="tool-status-bar__dot"></span>
-          <span className="tool-status-bar__dot"></span>
-        </span>
+      {onRecap && (
+        <RecapButton
+          onRecap={onRecap}
+          disabled={recapDisabled}
+          isRecapping={isRecapping}
+        />
       )}
-      <span className="tool-status-bar__text">{description}</span>
+      <div className="tool-status-bar__status">
+        {state === "active" && (
+          <span className="tool-status-bar__indicator" aria-hidden="true">
+            <span className="tool-status-bar__dot"></span>
+            <span className="tool-status-bar__dot"></span>
+            <span className="tool-status-bar__dot"></span>
+          </span>
+        )}
+        <span className="tool-status-bar__text">{description}</span>
+      </div>
     </div>
   );
 }

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -256,12 +256,17 @@ export const AbortMessageSchema = z.object({
   type: z.literal("abort"),
 });
 
+export const RecapMessageSchema = z.object({
+  type: z.literal("recap"),
+});
+
 export const ClientMessageSchema = z.discriminatedUnion("type", [
   AuthenticateMessageSchema,
   PlayerInputMessageSchema,
   StartAdventureMessageSchema,
   PingMessageSchema,
   AbortMessageSchema,
+  RecapMessageSchema,
 ]);
 
 export type ClientMessage = z.infer<typeof ClientMessageSchema>;
@@ -414,6 +419,51 @@ export const ToolStatusMessageSchema = z.object({
   }),
 });
 
+// ========================
+// Recap Messages (Server → Client)
+// ========================
+
+/**
+ * Sent when recap processing begins.
+ * Frontend should show a "recapping" state.
+ */
+export const RecapStartedMessageSchema = z.object({
+  type: z.literal("recap_started"),
+});
+
+export type RecapStartedMessage = z.infer<typeof RecapStartedMessageSchema>;
+
+/**
+ * Sent when recap completes successfully.
+ * Contains the updated history (retained entries only) and new summary.
+ * Frontend replaces current history/summary with these values.
+ */
+export const RecapCompleteMessageSchema = z.object({
+  type: z.literal("recap_complete"),
+  payload: z.object({
+    /** Retained history entries after compaction */
+    history: z.array(NarrativeEntrySchema),
+    /** New summary from compaction (null if summarization failed) */
+    summary: HistorySummarySchema.nullable(),
+  }),
+});
+
+export type RecapCompleteMessage = z.infer<typeof RecapCompleteMessageSchema>;
+
+/**
+ * Sent when recap fails.
+ * Contains a user-friendly error message.
+ */
+export const RecapErrorMessageSchema = z.object({
+  type: z.literal("recap_error"),
+  payload: z.object({
+    /** User-friendly error description */
+    reason: z.string(),
+  }),
+});
+
+export type RecapErrorMessage = z.infer<typeof RecapErrorMessageSchema>;
+
 export const ServerMessageSchema = z.discriminatedUnion("type", [
   GMResponseStartMessageSchema,
   GMResponseChunkMessageSchema,
@@ -427,6 +477,9 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
   PanelCreateMessageSchema,
   PanelUpdateMessageSchema,
   PanelDismissMessageSchema,
+  RecapStartedMessageSchema,
+  RecapCompleteMessageSchema,
+  RecapErrorMessageSchema,
 ]);
 
 export type ServerMessage = z.infer<typeof ServerMessageSchema>;


### PR DESCRIPTION
## Summary

Closes #185

Add a user-initiated "Recap" button that allows players to manually trigger history compaction and get a fresh "what next" prompt from the GM.

### Key Features

- **ForceSave before compaction**: Before archiving history, the GM is prompted to save all important narrative details to state files (sheet.md, world_state.md, etc.) to prevent data loss
- **Pending compaction flow**: Automatic compaction now sets a flag and waits for the current GM response to complete, then orchestrates forceSave → compact
- **Confirmation dialog**: Users must confirm before triggering recap
- **Two GM responses during recap**: One from forceSave (state checkpoint), one from the recap prompt (what next guidance)

### Changes

**Protocol** (`shared/protocol.ts`):
- `recap` client message
- `recap_started`, `recap_complete`, `recap_error` server messages

**Backend**:
- `forceSave()` method in GameSession - prompts GM to persist all state
- `compactionPending` flag in AdventureStateManager
- `appendHistory()` now sets flag instead of auto-compacting
- After `handleInput` completes, checks pending and orchestrates save+compact
- `handleRecap()` calls forceSave before compaction

**Frontend**:
- `RecapButton` component with subtle styling
- `RecapConfirmDialog` for confirmation before recap
- Integration into `ToolStatusBar` (left side)
- Message handlers for recap flow in App.tsx

## Test plan

- [x] Backend unit tests (800 pass)
- [x] Frontend unit tests (252 pass)
- [x] Typecheck clean
- [x] Lint clean
- [ ] Manual test: Click Recap button, confirm dialog appears
- [ ] Manual test: Confirm recap, see save + compaction + GM response
- [ ] Manual test: Verify state files are updated before compaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)