### PR TITLE
fix: add dual-constraint compaction algorithm (#192)

### DIFF
--- a/backend/src/adventure-state.ts
+++ b/backend/src/adventure-state.ts
@@ -326,6 +326,7 @@ export class AdventureStateManager {
 
     const compactor = new HistoryCompactor(adventureDir, {
       retainedCount: env.retainedEntryCount,
+      targetRetainedCharCount: env.targetRetainedCharCount,
       model: env.compactionSummaryModel,
     });
 

--- a/backend/src/types/state.ts
+++ b/backend/src/types/state.ts
@@ -57,8 +57,10 @@ export interface AdventureState {
  * Configuration for history compaction
  */
 export interface CompactionConfig {
-  /** Number of entries to retain after compaction */
+  /** Maximum number of entries to retain after compaction */
   retainedCount: number;
+  /** Target character budget for retained entries (0 = summarize all) */
+  targetRetainedCharCount: number;
   /** Model to use for summarization */
   model: string;
   /** Override for mock SDK mode (defaults to env.mockSdk) */

--- a/backend/tests/unit/env.test.ts
+++ b/backend/tests/unit/env.test.ts
@@ -12,6 +12,7 @@ import {
   parseLogLevel,
   parseAllowedOrigins,
   parseBoolean,
+  parseTargetRetainedCharCount,
   validateEnvironment,
   VALID_LOG_LEVELS,
 } from "../../src/env";
@@ -232,6 +233,35 @@ describe("parseBoolean", () => {
   });
 });
 
+describe("parseTargetRetainedCharCount", () => {
+  test("returns default 50000 when undefined", () => {
+    expect(parseTargetRetainedCharCount(undefined)).toBe(50000);
+  });
+
+  test("returns default 50000 when empty string", () => {
+    expect(parseTargetRetainedCharCount("")).toBe(50000);
+  });
+
+  test("parses valid values", () => {
+    expect(parseTargetRetainedCharCount("25000")).toBe(25000);
+    expect(parseTargetRetainedCharCount("100000")).toBe(100000);
+    expect(parseTargetRetainedCharCount("1")).toBe(1);
+  });
+
+  test("allows zero for full summarization", () => {
+    expect(parseTargetRetainedCharCount("0")).toBe(0);
+  });
+
+  test("throws for non-numeric value", () => {
+    expect(() => parseTargetRetainedCharCount("large")).toThrow("Invalid TARGET_RETAINED_CHAR_COUNT");
+  });
+
+  test("throws for negative value", () => {
+    expect(() => parseTargetRetainedCharCount("-1000")).toThrow("Invalid TARGET_RETAINED_CHAR_COUNT");
+    expect(() => parseTargetRetainedCharCount("-1")).toThrow("non-negative integer");
+  });
+});
+
 describe("validateEnvironment", () => {
   test("returns valid config with all defaults", () => {
     const result = validateEnvironment({});
@@ -325,6 +355,7 @@ describe("validateEnvironment", () => {
       replicateApiToken: "r8_abc123",
       compactionCharThreshold: 100000,
       retainedEntryCount: 20,
+      targetRetainedCharCount: 50000,
       compactionSummaryModel: "claude-3-5-haiku-latest",
     });
   });


### PR DESCRIPTION
## Summary

- Add `TARGET_RETAINED_CHAR_COUNT` env var (default 50000 chars) to cap retained content size
- Update `compact()` algorithm to use dual constraints: retain entries up to BOTH the entry count limit AND character budget
- `handleRecap` now passes `retainedCount=0` to summarize entire history for full context clearing
- Edge case: retain at least 1 entry if `retainedCount > 0`, even if it exceeds char budget

## Problem

The compaction system had a disconnect between **when** and **what** to compact:
- `shouldCompact()` triggered when history exceeded `compactionCharThreshold` (100k chars)
- `compact()` retained exactly `retainedCount` entries (20), ignoring character size
- After compaction, retained entries could still be 50k+ chars
- `handleRecap()` couldn't summarize entire history to clear context

## Test plan

- [x] Typecheck passes
- [x] Lint passes
- [x] All 811 unit tests pass
- [x] New tests for `parseTargetRetainedCharCount` (6 tests)
- [x] New tests for dual constraint behavior (5 tests)
- [x] Code review completed - no issues found

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)