### PR TITLE
feat: add drag-to-move for overlay panels

### DIFF
--- a/frontend/src/components/InfoPanel.css
+++ b/frontend/src/components/InfoPanel.css
@@ -30,6 +30,16 @@
   border-bottom: none;
 }
 
+/* Draggable header for overlay panels */
+.info-panel__header--draggable {
+  cursor: grab;
+  user-select: none;
+}
+
+.info-panel__header--draggable:active {
+  cursor: grabbing;
+}
+
 .info-panel__title {
   font-size: var(--font-size-sm);
   font-weight: 600;

--- a/frontend/src/components/InfoPanel.tsx
+++ b/frontend/src/components/InfoPanel.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useRef, useCallback } from "react";
 import Markdown from "react-markdown";
 import type { Panel } from "../types/protocol";
 import { usePanels } from "../contexts/PanelContext";
@@ -6,6 +6,8 @@ import "./InfoPanel.css";
 
 export interface InfoPanelProps {
   panel: Panel;
+  /** Whether this panel is in the overlay zone (enables drag) */
+  isOverlay?: boolean;
 }
 
 /**
@@ -16,17 +18,89 @@ export interface InfoPanelProps {
  * - Markdown content rendering with sanitization (REQ-NF-5, TD-3)
  * - Collapsed state shows only title bar when minimized
  * - Inherits theme styling via CSS variables (REQ-NF-4, TD-7)
+ * - Draggable header for overlay panels
  *
  * Security: Only permits p, strong, em, ul, ol, li elements via allowedElements.
  * This prevents XSS attacks by disallowing raw HTML and scripts.
  */
-function InfoPanelComponent({ panel }: InfoPanelProps) {
-  const { isMinimized, toggleMinimize } = usePanels();
+function InfoPanelComponent({ panel, isOverlay = false }: InfoPanelProps) {
+  const { isMinimized, toggleMinimize, updatePanelPosition } = usePanels();
   const minimized = isMinimized(panel.id);
+  const isDragging = useRef(false);
+  const dragOffset = useRef({ x: 0, y: 0 });
 
   const handleMinimizeClick = () => {
     toggleMinimize(panel.id);
   };
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isOverlay) return;
+
+      // Don't start drag if clicking the minimize button
+      if ((e.target as HTMLElement).closest("button")) return;
+
+      isDragging.current = true;
+
+      // Get the overlay container for percentage calculations
+      const overlayContainer = document.querySelector(".panel-zone--overlay");
+      if (!overlayContainer) return;
+
+      const containerRect = overlayContainer.getBoundingClientRect();
+      const panelElement = e.currentTarget.closest(
+        ".panel-zone__overlay-item"
+      ) as HTMLElement;
+      if (!panelElement) return;
+
+      const panelRect = panelElement.getBoundingClientRect();
+
+      // Calculate offset from panel center to mouse position (in percentage)
+      const panelCenterX =
+        ((panelRect.left + panelRect.width / 2 - containerRect.left) /
+          containerRect.width) *
+        100;
+      const panelCenterY =
+        ((panelRect.top + panelRect.height / 2 - containerRect.top) /
+          containerRect.height) *
+        100;
+      const mouseX =
+        ((e.clientX - containerRect.left) / containerRect.width) * 100;
+      const mouseY =
+        ((e.clientY - containerRect.top) / containerRect.height) * 100;
+
+      dragOffset.current = {
+        x: panelCenterX - mouseX,
+        y: panelCenterY - mouseY,
+      };
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        if (!isDragging.current) return;
+
+        const newMouseX =
+          ((moveEvent.clientX - containerRect.left) / containerRect.width) *
+          100;
+        const newMouseY =
+          ((moveEvent.clientY - containerRect.top) / containerRect.height) *
+          100;
+
+        // Clamp to keep panel mostly visible (5-95%)
+        const newX = Math.max(5, Math.min(95, newMouseX + dragOffset.current.x));
+        const newY = Math.max(5, Math.min(95, newMouseY + dragOffset.current.y));
+
+        updatePanelPosition(panel.id, newX, newY);
+      };
+
+      const handleMouseUp = () => {
+        isDragging.current = false;
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [isOverlay, panel.id, updatePanelPosition]
+  );
 
   return (
     <div
@@ -34,7 +108,10 @@ function InfoPanelComponent({ panel }: InfoPanelProps) {
       data-testid={`info-panel-${panel.id}`}
       data-panel-id={panel.id}
     >
-      <div className="info-panel__header">
+      <div
+        className={`info-panel__header ${isOverlay ? "info-panel__header--draggable" : ""}`}
+        onMouseDown={handleMouseDown}
+      >
         <span className="info-panel__title">{panel.title}</span>
         <button
           type="button"

--- a/frontend/src/components/PanelZones.tsx
+++ b/frontend/src/components/PanelZones.tsx
@@ -82,8 +82,10 @@ function HeaderPanelZoneComponent() {
  *
  * Note: Overlay panels use panel.x and panel.y for positioning.
  * Default to center (50%, 50%) if x/y not specified.
+ * Position can be overridden by dragging (stored in PanelContext).
  */
 function OverlayPanelContainerComponent() {
+  const { getPanelPosition } = usePanels();
   const overlayPanels = usePanelsByPosition("overlay");
 
   if (overlayPanels.length === 0) {
@@ -96,20 +98,26 @@ function OverlayPanelContainerComponent() {
       data-testid="panel-zone-overlay"
       aria-label="Overlay panels"
     >
-      {overlayPanels.map((panel, index) => (
-        <div
-          key={panel.id}
-          className="panel-zone__overlay-item"
-          style={{
-            left: `${panel.x ?? 50}%`,
-            top: `${panel.y ?? 50}%`,
-            // Stack in creation order - older panels below newer ones
-            zIndex: 100 + index,
-          }}
-        >
-          <InfoPanel panel={panel} />
-        </div>
-      ))}
+      {overlayPanels.map((panel, index) => {
+        const positionOverride = getPanelPosition(panel.id);
+        const x = positionOverride?.x ?? panel.x ?? 50;
+        const y = positionOverride?.y ?? panel.y ?? 50;
+
+        return (
+          <div
+            key={panel.id}
+            className="panel-zone__overlay-item"
+            style={{
+              left: `${x}%`,
+              top: `${y}%`,
+              // Stack in creation order - older panels below newer ones
+              zIndex: 100 + index,
+            }}
+          >
+            <InfoPanel panel={panel} isOverlay />
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Overlay panels can now be repositioned by dragging their header
- Position stored locally in PanelContext (not persisted to server)
- Panels clamped to 5-95% to keep them visible

## Test plan
- [ ] Open an adventure with overlay panels
- [ ] Drag panel header to move panel
- [ ] Verify cursor changes to grab/grabbing
- [ ] Verify minimize button still works (not affected by drag)
- [ ] Verify panels stay within viewport bounds

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)