### PR TITLE
Fix Daggerheart leveling documentation to match SRD

### DIFF
--- a/daggerheart-system/System.md
+++ b/daggerheart-system/System.md
@@ -87,6 +87,7 @@ Action roll difficulties use these standard values:
 Hope and Fear tokens represent narrative momentum.
 
 ### Hope Tokens (Player)
+- Starting: 2 per character
 - Maximum: 6 per character
 - Gained when your hope die is higher on an action roll
 - Spend to: Reroll a die, boost damage, activate certain class features
@@ -244,6 +245,65 @@ Each class has:
 - Subclass options (chosen at character creation)
 - Level advancement features
 - Domain access (2 domains)
+
+---
+
+## Leveling Up
+
+The party levels up together when the GM decides a narrative milestone has been reached (typically every 3 sessions).
+
+### Tiers
+
+Daggerheart's 10 levels are divided into 4 tiers:
+
+| Tier | Levels |
+|------|--------|
+| Tier 1 | 1 |
+| Tier 2 | 2-4 |
+| Tier 3 | 5-7 |
+| Tier 4 | 8-10 |
+
+Your tier affects damage thresholds, tier achievements, and advancement access.
+
+### Level Up Process
+
+Follow these four steps each time the party levels up:
+
+**Step 1: Tier Achievements**
+
+When entering a new tier (levels 2, 5, 8):
+
+| Level | Achievement |
+|-------|-------------|
+| 2 | +1 Experience at +2, +1 Proficiency |
+| 5 | +1 Experience at +2, +1 Proficiency, clear marked traits |
+| 8 | +1 Experience at +2, +1 Proficiency, clear marked traits |
+
+**Step 2: Choose Two Advancements**
+
+Pick two from your current tier or below:
+
+| Advancement | Effect |
+|-------------|--------|
+| Increase Traits | +1 to 2 unmarked traits (mark them until next tier) |
+| Add HP Slot | +1 HP slot permanently |
+| Add Stress Slot | +1 Stress slot permanently |
+| Increase Experience | +1 to 2 Experiences |
+| Additional Domain Card | Take a card at or below your level |
+| Increase Evasion | +1 Evasion permanently |
+| Upgrade Subclass Card | Foundation → Specialization → Mastery |
+| Increase Proficiency* | +1 Proficiency, +1 weapon damage die |
+| Multiclass* | Gain second class feature and domain |
+
+*Costs 2 advancement slots
+
+**Step 3: Increase Damage Thresholds**
+
+All thresholds increase by 1 each level.
+
+**Step 4: Gain Domain Card**
+
+Take a new domain card at your level or lower. You may also swap one existing card for another of equal or lower level.
 
 ---
 

--- a/daggerheart-system/skills/dh-players/SKILL.md
+++ b/daggerheart-system/skills/dh-players/SKILL.md
@@ -204,7 +204,7 @@ Armor provides:
 
 ## Hope
 
-Characters can hold up to 6 Hope tokens.
+Characters can hold up to 6 Hope tokens. **At character creation, start with 2 Hope.**
 
 **Gaining Hope**: When your hope die is higher on an action roll
 
@@ -257,39 +257,77 @@ The sheet.md file must include:
 
 ## Level Advancement
 
-Characters advance from level 1 to level 10.
+Characters advance from level 1 to level 10. The party levels up together whenever the GM decides a narrative milestone has been reached (typically every 3 sessions).
 
-### Level Advancement Table
+### Tiers
 
-| Level | Features |
-|-------|----------|
-| 1 | Starting class features, subclass Foundation card, ancestry features, community feature |
-| 2 | Subclass feature |
-| 3 | Class feature |
-| 4 | Trait improvement (+1 to any trait, max +3) |
-| 5 | Class feature |
-| 6 | Subclass feature |
-| 7 | Class feature |
-| 8 | Trait improvement (+1 to any trait, max +3) |
-| 9 | Class feature |
-| 10 | Subclass capstone feature |
+Daggerheart's 10 levels are divided into 4 tiers that affect damage thresholds, tier achievements, and advancement access:
+
+| Tier | Levels | Significance |
+|------|--------|--------------|
+| Tier 1 | 1 | Starting tier |
+| Tier 2 | 2-4 | First tier achievements unlock |
+| Tier 3 | 5-7 | Mid-level power increase |
+| Tier 4 | 8-10 | High-level mastery |
 
 ### Level Up Steps
 
-1. **Increase Level** - Update level in character identity
-2. **Update Thresholds** - Damage thresholds increase with level
-3. **Gain Features** - Add class/subclass features for the new level
-4. **Trait Improvement** (Levels 4, 8) - Increase one trait modifier by +1 (max +3)
-5. **Additional Domain Cards** - Gain access to higher-level cards
-6. **Update Proficiency** - Some features scale with level
+Follow these four steps each time the party levels up:
 
-### Threshold Scaling
+#### Step 1: Tier Achievements
 
-As level increases, damage thresholds increase:
+When entering a new tier (levels 2, 5, 8), gain these benefits:
+
+| Level | Tier Achievement |
+|-------|------------------|
+| 2 | Gain a new Experience at +2, permanently increase Proficiency by 1 |
+| 5 | Gain a new Experience at +2, permanently increase Proficiency by 1, clear any marked traits |
+| 8 | Gain a new Experience at +2, permanently increase Proficiency by 1, clear any marked traits |
+
+#### Step 2: Choose Advancements
+
+Choose **two advancements** from your current tier or below. Each advancement has slots; mark one slot when chosen. Options with multiple slots can be taken multiple times.
+
+| Advancement | Effect | Slots |
+|-------------|--------|-------|
+| Increase Traits | Choose 2 unmarked traits, gain +1 to each, mark them (can't increase again until next tier clears marks) | Per tier |
+| Add HP Slot | Permanently add 1 HP slot | Multiple |
+| Add Stress Slot | Permanently add 1 Stress slot | Multiple |
+| Increase Experience | Choose 2 Experiences, gain +1 to each | Multiple |
+| Additional Domain Card | Take a domain card at or below your level from your class's domains | Multiple |
+| Increase Evasion | Gain permanent +1 to Evasion | Multiple |
+| Upgrade Subclass Card | Take the next subclass card (Foundation → Specialization → Mastery). Locks out multiclass option for this tier. | Per tier |
+| Increase Proficiency | Increase Proficiency by 1, add 1 damage die to weapon. **Costs 2 advancement slots.** | Per tier |
+| Multiclass | Choose additional class, gain its class feature and one domain. Take foundation card from one of its subclasses. Locks out upgraded subclass and future multiclass. **Costs 2 advancement slots.** | Once ever |
+
+#### Step 3: Increase Damage Thresholds
+
+All damage thresholds increase by 1:
 - Major = Level + Armor Major Base
 - Severe = Level + Armor Severe Base
 
-This makes characters more durable as they advance.
+#### Step 4: Gain Domain Card
+
+Acquire a new domain card at your level or lower from one of your class's domains. Add it to your loadout or vault. You may also exchange one previously acquired card for a different card of the same level or lower.
+
+### Proficiency
+
+Proficiency determines the number of damage dice rolled with weapons. It increases:
+- At character creation (class-based starting value)
+- At tier achievements (levels 2, 5, 8)
+- Via the "Increase Proficiency" advancement (costs 2 slots)
+
+### Recording Level Up Changes
+
+Update the character sheet (`players/{slug}/sheet.md`) with:
+1. New level number
+2. Updated damage thresholds
+3. New Experiences (if tier achievement)
+4. Updated Proficiency (if tier achievement or advancement)
+5. Marked advancement slots
+6. Marked traits (if "Increase Traits" was chosen)
+7. New domain cards
+8. Any new HP/Stress/Evasion values
 
 ## Multiclassing
 

--- a/daggerheart-system/skills/dh-players/references/sheet-template.md
+++ b/daggerheart-system/skills/dh-players/references/sheet-template.md
@@ -55,7 +55,8 @@
 <!--
   COMBAT STATISTICS
   =================
-  Evasion: Class Base + Agility modifier
+  Evasion: Class Base (NOT modified by traits)
+  Proficiency: Determines weapon damage dice, increases at tier achievements
   HP Slots: Typically 6, mark when taking damage
   Stress Slots: Typically 6, gain Vulnerable when maxed
   Armor Score: Reduces incoming damage
@@ -66,7 +67,8 @@
 
 | Stat              | Value                        |
 |-------------------|------------------------------|
-| Evasion           | [Class Base] + [Agility mod] = [Total] |
+| Evasion           | [Class Base]                 |
+| Proficiency       | [#] (weapon damage dice)     |
 | HP Slots          | ○○○○○○                       |
 | Stress Slots      | ○○○○○○                       |
 | Armor Score       | [Value]                      |
@@ -93,7 +95,7 @@ Armor Slots: ○○○
   Mark filled slots with ●, empty with ○
 -->
 
-Hope: ○○○○○○ (0/6)
+Hope: ●●○○○○ (2/6)
 
 ---
 
@@ -289,6 +291,49 @@ Hope: ○○○○○○ (0/6)
 
 **[Feature Name]**
 [Feature description]
+
+---
+
+## Level Advancement
+
+<!--
+  LEVEL ADVANCEMENT TRACKING
+  ==========================
+  Track advancements taken at each level.
+  Mark trait boxes when "Increase Traits" is chosen (clear at tier transitions).
+
+  Tiers: 1 (Lv1), 2 (Lv2-4), 3 (Lv5-7), 4 (Lv8-10)
+  Tier Achievements at levels 2, 5, 8: +1 Experience, +1 Proficiency
+-->
+
+### Marked Traits
+
+<!-- Mark traits increased via "Increase Traits" advancement. Clear at tier transitions (levels 5, 8). -->
+
+| Trait     | Marked |
+|-----------|--------|
+| Agility   | [ ]    |
+| Strength  | [ ]    |
+| Finesse   | [ ]    |
+| Instinct  | [ ]    |
+| Presence  | [ ]    |
+| Knowledge | [ ]    |
+
+### Advancements Taken
+
+<!-- Record advancements chosen at each level up -->
+
+| Level | Advancement 1 | Advancement 2 |
+|-------|---------------|---------------|
+| 2     |               |               |
+| 3     |               |               |
+| 4     |               |               |
+| 5     |               |               |
+| 6     |               |               |
+| 7     |               |               |
+| 8     |               |               |
+| 9     |               |               |
+| 10    |               |               |
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace incorrect D20-style leveling table with proper Daggerheart tier-based system
- Add all 9 advancement options with correct slot costs (Increase Proficiency and Multiclass cost 2 slots)
- Document tier achievements at levels 2, 5, 8
- Add Proficiency tracking and Level Advancement section to character sheet template
- Fix starting Hope to 2 (was incorrectly shown as 0)

Closes #216

## Test plan

- [x] Verified leveling rules match SRD source (`docs/research/daggerheart-srd/contents/Leveling Up.md`)
- [x] All 4 level-up steps documented
- [x] All 9 advancement options correctly described
- [x] Linter passes
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)