### PR TITLE
feat: add dh-frame skill for campaign frames #213

### DIFF
--- a/daggerheart-system/CLAUDE.md
+++ b/daggerheart-system/CLAUDE.md
@@ -1,6 +1,6 @@
 # Daggerheart System Plugin
 
-This plugin provides Daggerheart RPG mechanics for Adventure Engine adventures. It offers skills for character creation with bounded Experiences, Hope/Fear token economy, spotlight-based combat, domain cards, adversary management, and authoritative SRD rule lookups.
+This plugin provides Daggerheart RPG mechanics for Adventure Engine adventures. It offers skills for campaign frames, character creation with bounded Experiences, Hope/Fear token economy, spotlight-based combat, domain cards, adversary management, and authoritative SRD rule lookups.
 
 ## Getting Started
 
@@ -32,6 +32,9 @@ Domain card reference and Spellcast guidance. Invoke when players use domain abi
 
 ### dh-rules
 Authoritative Daggerheart SRD rule lookups. Invoke when users ask "what does the SRD say about...", "official rules for...", or need exact rule wording. Contains grep patterns for efficient SRD searching.
+
+### dh-frame
+Campaign frame selection and world building. Invoke when starting a new campaign, establishing tone and themes, selecting or creating a campaign frame, or reframing an existing adventure. Frames provide pitch, themes, community/class guidance, principles, distinctions, and special mechanics for a particular story type.
 
 ## Dice-Roller Integration
 
@@ -108,6 +111,7 @@ Each skill contains detailed reference materials in its `references/` subdirecto
 | dh-combat | `action-outcomes.md`, `encounter-template.md`, `conditions.md` |
 | dh-domains | `domain-overview.md` |
 | dh-rules | `srd/` (Daggerheart SRD via symlink), `License.md` |
+| dh-frame | `frame-template.md`, `frame-structure.md`, `srd/` (SRD frames via symlink) |
 
 Load references progressively - invoke the skill first, then read specific reference files only when detailed information is needed.
 
@@ -126,7 +130,8 @@ daggerheart-system/
     ├── dh-combat/
     ├── dh-adversaries/
     ├── dh-domains/
-    └── dh-rules/
+    ├── dh-rules/
+    └── dh-frame/
 ```
 
 ## Key Differences from d20-System

--- a/daggerheart-system/skills/dh-frame/SKILL.md
+++ b/daggerheart-system/skills/dh-frame/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: dh-frame
+description: This skill should be used when creating a new Daggerheart campaign, establishing world tone and themes, selecting or building a campaign frame, or reframing an existing adventure. Campaign frames provide pitch, tone, themes, community/ancestry/class guidance, principles, distinctions, inciting incidents, and special mechanics for a particular type of story.
+version: 1.0.0
+---
+
+# Campaign Frame Skill
+
+Guide GMs through selecting, customizing, or creating campaign frames that shape the tone, themes, and mechanics of a Daggerheart adventure.
+
+**Authoritative Source**: For official frame content, reference the SRD frames in `references/srd/`.
+
+## What is a Campaign Frame?
+
+A campaign frame is a template that provides inspiration, tools, and mechanics to support a particular type of story. Frames establish the narrative foundation before character creation begins, ensuring all players share expectations about tone, themes, and the world they'll inhabit.
+
+Every campaign frame has a **complexity rating** (● to ●●●) indicating how much its mechanics deviate from core Daggerheart rules.
+
+## When to Use This Skill
+
+### Initial World Creation (Primary Use)
+
+Invoke this skill when starting a new Daggerheart campaign to:
+- Select an existing SRD frame or create a custom one
+- Establish tone, themes, and touchstones
+- Prepare session zero questions
+- Identify special mechanics that will apply
+
+### Player-Initiated Reframing
+
+Players may request reframing when:
+- The campaign's direction has shifted significantly
+- The group wants to explore different themes
+- A major narrative turning point demands new framing
+
+When reframing, preserve continuity while adjusting:
+- Tone and feel (can shift based on story events)
+- Active principles (which ones are most relevant now)
+- Distinctions (new world elements revealed)
+
+### GM-Initiated Mid-Adventure Reframing (Rare)
+
+GMs might reframe when:
+- A major world-changing event occurs
+- The campaign pivots to a new arc with different themes
+- Players have outgrown the original frame's scope
+
+**Caution**: Mid-adventure reframing should be discussed with players. Sudden tonal shifts without buy-in can feel jarring.
+
+## Frame Structure
+
+Each campaign frame includes these sections:
+
+| Section | Purpose |
+|---------|---------|
+| **Pitch** | 2-3 sentence hook to present to players |
+| **Tone & Feel** | Adjectives describing the emotional atmosphere |
+| **Themes** | Core narrative tensions and questions explored |
+| **Touchstones** | Media references that capture the vibe |
+| **Overview** | Background lore and setting context |
+| **Communities** | How SRD communities fit this setting |
+| **Ancestries** | Ancestry-specific adaptations |
+| **Classes** | Class-specific setting connections |
+| **Player Principles** | Guidelines for player roleplay |
+| **GM Principles** | Guidelines for GM narration |
+| **Distinctions** | Unique setting elements and rules |
+| **Inciting Incident** | Campaign-starting scenario |
+| **Campaign Mechanics** | Special rules unique to this frame |
+| **Session Zero Questions** | Discussion prompts for character creation |
+
+For detailed explanations, see `references/frame-structure.md`.
+
+## Using an SRD Frame
+
+The Daggerheart SRD includes official campaign frames. To use one:
+
+1. **Read the frame** from `references/srd/`
+2. **Present the pitch** to players before session zero
+3. **Share tone, themes, and touchstones** so players understand expectations
+4. **During session zero**, use the community/ancestry/class guidance and questions
+5. **Record frame elements** in your world's documentation
+6. **Apply campaign mechanics** as specified in the frame
+7. **Initialize resources** - GM starts with 5 Fear tokens
+
+### Campaign Resource Initialization
+
+When a new campaign begins:
+
+| Resource | Starting Value |
+|----------|---------------|
+| GM Fear tokens | 5 |
+| Player Hope tokens | 2 each (per character creation) |
+
+The GM's starting Fear provides immediate narrative options for the opening session without requiring player failures first.
+
+### Recording Frame Selection
+
+When using a frame, document it in `worlds/{slug}/world_state.md`:
+
+```markdown
+## Campaign Frame
+
+**Frame**: [Frame Name]
+**Complexity**: [● to ●●●]
+
+### Active Themes
+- [Theme 1]
+- [Theme 2]
+
+### Session Zero Answers
+> [Question from frame]
+[Player/group answer]
+
+### Special Mechanics
+[Any frame-specific rules in effect]
+```
+
+## Creating a Custom Frame
+
+Use `references/frame-template.md` as a starting point. Fill in each section thoughtfully:
+
+### Step 1: Define the Core Concept
+
+Start with:
+- **Pitch**: What's the elevator pitch? (2-3 sentences max)
+- **Tone & Feel**: List 5-7 adjectives
+- **Themes**: What tensions will the campaign explore?
+- **Touchstones**: What media captures the vibe?
+
+### Step 2: Establish the World
+
+Write the **Overview** section covering:
+- Recent history leading to current tensions
+- Major factions or forces in conflict
+- What the world was like before and what changed
+- Stakes for the characters
+
+### Step 3: Adapt Character Options
+
+For each community, ancestry, and class:
+- How does it fit this setting?
+- What unique aspects exist here?
+- What session zero questions connect characters to the frame?
+
+### Step 4: Define Principles
+
+**Player Principles** should encourage:
+- Engagement with frame themes
+- Character vulnerability appropriate to tone
+- Roleplay that reinforces the setting
+
+**GM Principles** should guide:
+- How to portray NPCs and factions
+- What kinds of challenges to present
+- How to maintain tonal consistency
+
+### Step 5: Create Distinctions
+
+Distinctions are unique setting elements:
+- Geography, time, or cosmological differences
+- Social structures or customs
+- Supernatural elements or unique dangers
+
+Each distinction should have narrative and potentially mechanical implications.
+
+### Step 6: Design the Inciting Incident
+
+The inciting incident should:
+- Thrust characters into the central conflict
+- Connect to frame themes
+- Provide clear initial direction
+- Leave room for player agency
+
+### Step 7: Add Campaign Mechanics (Optional)
+
+If your frame requires special rules:
+- Keep complexity appropriate to the rating
+- Clearly explain triggers and effects
+- Consider how mechanics reinforce themes
+
+### Step 8: Prepare Session Zero Questions
+
+Questions should:
+- Connect characters to the world
+- Establish relationships and stakes
+- Reveal backstory relevant to themes
+- Vary by community/ancestry/class where appropriate
+
+## Complexity Ratings
+
+| Rating | Meaning |
+|--------|---------|
+| ● | Minimal mechanical changes; mostly narrative framing |
+| ●● | Some new mechanics or modified rules |
+| ●●● | Significant mechanical additions; requires familiarity with core rules |
+
+## Integration with World Building
+
+Frame elements should flow into your world documentation:
+
+| Frame Section | Maps To |
+|---------------|---------|
+| Overview | `worlds/{slug}/world_state.md` |
+| Communities/Ancestries/Classes | Character creation guidance |
+| Distinctions | `worlds/{slug}/locations.md`, custom rules |
+| Inciting Incident | Opening session prep |
+| NPCs from frame | `worlds/{slug}/characters.md` |
+| Session Zero Answers | Player backstory integration |
+
+## Reframing an Existing Campaign
+
+When reframing mid-campaign:
+
+1. **Discuss with players** - Get buy-in for the tonal/thematic shift
+2. **Identify what persists** - Core relationships, ongoing plots, character arcs
+3. **Define what changes** - New themes, adjusted tone, revealed distinctions
+4. **Update documentation** - Revise world_state.md to reflect new frame
+5. **Introduce narratively** - The reframe should feel earned, not arbitrary
+
+### Partial Reframing
+
+Sometimes only parts of the frame need adjustment:
+- **Tone shift**: The story grows darker or lighter
+- **New themes emerge**: Original themes resolve, new ones arise
+- **Distinctions revealed**: Hidden world elements come to light
+
+Document changes as "Frame Evolution" in world_state.md.
+
+## References
+
+- `references/frame-template.md` - Blank template for custom frames
+- `references/frame-structure.md` - Detailed explanation of each section
+- `references/srd/` - Official Daggerheart SRD frames

--- a/daggerheart-system/skills/dh-frame/references/frame-structure.md
+++ b/daggerheart-system/skills/dh-frame/references/frame-structure.md
@@ -1,0 +1,235 @@
+# Campaign Frame Structure
+
+This document explains each section of a Daggerheart campaign frame in detail, providing guidance for both using existing frames and creating custom ones.
+
+## Frame Name and Tagline
+
+The frame name should be evocative and memorable. The tagline (in italics) captures the central tension or premise in a single sentence.
+
+**Good taglines**:
+- Establish conflict or stakes
+- Hint at the unique setting element
+- Create intrigue without spoiling
+
+**Example**: *"When an invading nation attacks an ancient forest deity, a virulent overgrowth spreads throughout the land."*
+
+## Complexity Rating
+
+Complexity ratings help groups choose frames appropriate to their experience level:
+
+| Rating | Description | Best For |
+|--------|-------------|----------|
+| ● | Minimal mechanical changes. The frame is primarily narrative, using standard Daggerheart rules with thematic guidance. | New groups, one-shots, lighter play |
+| ●● | Moderate mechanical additions. Introduces 1-2 new subsystems or modifies existing rules in limited ways. | Groups comfortable with core rules |
+| ●●● | Significant mechanical complexity. Multiple new systems that interact with each other and core rules. | Experienced groups seeking crunch |
+
+## The Pitch
+
+The pitch is a **player-facing** introduction read aloud before session zero. It should:
+
+- Be 2-3 sentences maximum
+- Establish the setting's unique hook
+- Describe what characters will be doing
+- Create buy-in without overwhelming detail
+- Use evocative language that sets tone
+
+**Write the pitch in second person** ("you'll play...") to help players imagine themselves in the world.
+
+## Tone & Feel
+
+A comma-separated list of 5-7 adjectives describing the emotional atmosphere. These guide:
+
+- How the GM describes scenes
+- What kind of moments to create
+- Player expectations for roleplay
+
+**Common tone adjectives**:
+- Adventurous, Bleak, Comedic, Dark, Epic, Gritty, Heroic, Hopeful, Horrific, Lighthearted, Melancholic, Mysterious, Romantic, Tense, Thrilling, Tragic, Uncanny, Whimsical
+
+Mix tones for nuance: "Dark, Hopeful, Uncanny" suggests horror with redemption themes.
+
+## Themes
+
+Themes are the narrative tensions and questions the campaign explores. Good themes:
+
+- Present genuine tensions without easy answers
+- Connect to character choices
+- Drive conflict at multiple scales (personal, faction, world)
+- Can evolve as the campaign progresses
+
+**Theme formats**:
+- Single concepts: *Redemption, Survival, Identity*
+- Tensions: *Freedom vs. Security, Nature vs. Civilization*
+- Questions: *What makes someone a hero?*
+
+List 3-6 themes. Too many dilutes focus; too few limits story potential.
+
+## Touchstones
+
+Media references that capture the frame's vibe. Include:
+
+- 3-5 references across different media (film, books, games, TV)
+- Works that share tone, themes, or aesthetic
+- Mix well-known and niche references
+
+Touchstones help players and GMs quickly align expectations. If someone hasn't experienced a touchstone, they can seek it out for inspiration.
+
+## Overview
+
+The overview is **GM-facing** background shared with players before character creation. Structure it as:
+
+1. **The Before**: What was the world like before current events?
+2. **The Inciting Change**: What happened to create the current crisis?
+3. **The Current State**: What is life like now?
+4. **The Factions**: Who are the major players and what do they want?
+5. **Why Characters Matter**: What role will PCs play?
+
+Length: 3-6 paragraphs. Dense enough to establish the world, concise enough to read in one sitting.
+
+## Communities
+
+For each SRD community that has unique aspects in this frame:
+
+1. **Context**: How does this community exist in the setting?
+2. **Unique aspects**: What's different about them here?
+3. **Session zero questions**: 2-3 questions connecting characters to the frame
+
+Questions should:
+- Reference frame-specific elements
+- Create hooks for future story
+- Establish relationships or backstory
+- Vary in emotional weight
+
+Not every community needs coverage. Focus on those with significant differences.
+
+## Ancestries
+
+Similar to communities, but focus on:
+
+- Physical or cultural differences in this setting
+- How frame events have affected this ancestry
+- Any mechanical implications (rare)
+
+Keep ancestry sections brief unless major changes apply.
+
+## Classes
+
+Describe how each class fits the setting:
+
+- Where do they come from? (institutions, traditions, origins)
+- What role do they play in current events?
+- How might players connect their class to factions?
+
+Group related classes together (e.g., "Warriors and Wizards" if both relate to the same institution).
+
+## Player Principles
+
+3-4 principles guiding player roleplay. Each principle should:
+
+- Have a clear, memorable name
+- Explain what it means in 2-3 sentences
+- Connect to frame themes
+- Encourage specific types of scenes or choices
+
+**Good player principles**:
+- Encourage vulnerability and emotional engagement
+- Push characters into frame-appropriate conflicts
+- Create opportunities for memorable moments
+
+## GM Principles
+
+3-4 principles guiding GM narration. Each should:
+
+- Have a clear, memorable name
+- Provide actionable guidance
+- Help maintain tonal consistency
+- Suggest specific techniques
+
+**Good GM principles**:
+- Guide NPC portrayal
+- Shape challenge design
+- Reinforce themes through world response
+- Balance opposing tones (e.g., horror and hope)
+
+## Distinctions
+
+Distinctions are unique setting elements that make this frame special. Each distinction should:
+
+- Have a memorable name
+- Explain what it is and how it works
+- Describe its impact on daily life
+- Suggest potential complications or story hooks
+
+**Types of distinctions**:
+- **Cosmological**: Different time, seasons, celestial bodies
+- **Geographic**: Unique terrain, magical locations
+- **Social**: Unusual customs, power structures, relationships
+- **Supernatural**: Magic systems, divine beings, curses
+- **Technological**: Unusual tech levels, specific inventions
+
+Distinctions can have mechanical implications. If so, explain clearly.
+
+## The Inciting Incident
+
+The scenario that launches the campaign. Include:
+
+1. **The situation**: What's happening right now?
+2. **Key NPCs**: 2-3 characters who set events in motion
+3. **The hook**: Why are the PCs involved?
+4. **Initial direction**: Where do they go first?
+
+The inciting incident should:
+- Connect to frame themes immediately
+- Give clear initial objectives
+- Leave room for player agency
+- Introduce major factions or conflicts
+
+Provide an example incident but note GMs can create their own.
+
+## Campaign Mechanics
+
+Special rules unique to this frame. For each mechanic:
+
+1. **Name**: Clear, thematic name
+2. **Trigger**: What causes this mechanic to activate?
+3. **Procedure**: Step-by-step how it works
+4. **Consequences**: What happens as a result?
+5. **Tokens/Tracking**: Any resources involved
+
+Keep mechanics:
+- Simple enough to remember
+- Thematically resonant
+- Integrated with core Daggerheart rules
+- Tested for balance (if possible)
+
+## Session Zero Questions
+
+Questions for players to answer during session zero. Include:
+
+- 4-8 general questions any character might answer
+- Community/ancestry/class-specific questions in those sections
+
+**Question types**:
+- World-building: Players define setting details
+- Relationship: Connections to NPCs or other PCs
+- Backstory: Personal history relevant to themes
+- Stakes: What does the character fear losing?
+- Secrets: Hidden aspects that may emerge in play
+
+Questions should be open-ended, avoiding yes/no answers.
+
+## Integration Checklist
+
+When using or creating a frame, ensure:
+
+- [ ] Pitch is concise and compelling
+- [ ] Tone adjectives align with themes
+- [ ] Themes present genuine tensions
+- [ ] Touchstones are accessible and relevant
+- [ ] Overview covers before/change/now/factions/PCs
+- [ ] Community/ancestry/class sections include questions
+- [ ] Principles are actionable, not vague
+- [ ] Distinctions have clear implications
+- [ ] Inciting incident provides clear direction
+- [ ] Mechanics are explained step-by-step
+- [ ] Session zero questions are open-ended

--- a/daggerheart-system/skills/dh-frame/references/frame-template.md
+++ b/daggerheart-system/skills/dh-frame/references/frame-template.md
@@ -1,0 +1,138 @@
+# [FRAME NAME]
+
+***[One-sentence tagline that captures the central conflict or premise]***
+
+*Designed by [Author(s)]*
+
+**COMPLEXITY RATING:** [● | ●● | ●●●]
+
+## THE PITCH
+
+Read this section to your players to introduce them to the campaign.
+
+> *[2-3 sentences that hook players into the world and central conflict. What makes this setting unique? What will characters be doing? What's at stake?]*
+
+## TONE & FEEL
+
+[List 5-7 adjectives separated by commas, e.g., Adventurous, Dark, Hopeful, Mysterious, Tense]
+
+## THEMES
+
+[List 3-6 themes separated by commas, e.g., Redemption, Sacrifice, Trust vs. Suspicion, Nature vs. Civilization]
+
+## TOUCHSTONES
+
+*[List 3-5 media references that capture the vibe: films, books, games, TV shows]*
+
+## OVERVIEW
+
+*If your group decides to play this campaign, give your players the following information before character creation.*
+
+[3-6 paragraphs covering:
+- What the world was like before the current crisis
+- What happened to create the current situation
+- The major factions or forces in conflict
+- What life is like now for ordinary people
+- Why the player characters will matter]
+
+## COMMUNITIES
+
+*All communities are available, but some have unique aspects within this campaign. As needed, provide the following information to your players and choose one or more of the questions to ask them during your session zero.*
+
+#### [COMMUNITY NAME]
+
+[1-2 paragraphs describing how this community fits the setting]
+
+> *[Session zero question 1]*
+>
+> *[Session zero question 2]*
+>
+> *[Session zero question 3]*
+
+[Repeat for each community with unique aspects in this frame]
+
+## ANCESTRIES
+
+*All ancestries are available, but some have unique aspects within this campaign. As needed, provide the following information to your players.*
+
+#### [ANCESTRY NAME]
+
+[Brief description of how this ancestry is different or special in this setting]
+
+[Repeat for ancestries with unique aspects]
+
+## CLASSES
+
+*All classes are available, but some have unique aspects within this campaign. As needed, provide the following information to your players.*
+
+#### [CLASS NAME(S)]
+
+[Description of how these classes fit the setting, their role in the world, and any special considerations]
+
+[Repeat for classes with unique aspects]
+
+## PLAYER PRINCIPLES
+
+*If your group decides to play this campaign, give your players the following information before character creation.*
+
+#### [PRINCIPLE NAME]
+
+[2-3 sentences explaining what this principle means and how players should embody it]
+
+[Repeat for 3-4 player principles]
+
+## GM PRINCIPLES
+
+*Keep the following guidance in mind while you GM this campaign.*
+
+#### [PRINCIPLE NAME]
+
+[2-3 sentences explaining how to apply this principle when running the game]
+
+[Repeat for 3-4 GM principles]
+
+## DISTINCTIONS
+
+*Use this information to prepare your campaign. You can also share it with your players as needed.*
+
+#### [DISTINCTION NAME]
+
+[1-3 paragraphs describing this unique setting element: what it is, how it works, and its impact on daily life or the story]
+
+[Repeat for each major setting distinction]
+
+## THE INCITING INCIDENT
+
+*You can use the prompt below to start your campaign, or create your own.*
+
+[2-4 paragraphs describing:
+- The situation that brings the party together
+- Key NPCs involved in launching the campaign
+- The immediate problem or opportunity
+- Clear first steps for the party to take]
+
+## CAMPAIGN MECHANICS
+
+*The following mechanics are unique to this campaign.*
+
+#### [MECHANIC NAME]
+
+[Clear explanation of:
+- What triggers this mechanic
+- How it works mechanically
+- What the consequences are
+- Any tokens, tracking, or resources involved]
+
+[Repeat for each special mechanic]
+
+#### SESSION ZERO QUESTIONS
+
+*Ask any of these questions to your players, or make your own.*
+
+> *[Question 1 - something about the world or setting]*
+>
+> *[Question 2 - something about character relationships]*
+>
+> *[Question 3 - something about personal stakes]*
+>
+> *[Question 4 - something that establishes backstory]*

--- a/daggerheart-system/skills/dh-frame/references/srd
+++ b/daggerheart-system/skills/dh-frame/references/srd
@@ -1,0 +1,1 @@
+../../../../docs/research/daggerheart-srd/frames


### PR DESCRIPTION
## Summary

- Add new `dh-frame` skill to daggerheart-system plugin for campaign frame selection and world building
- Covers three use cases: GM initial world creation, player-initiated reframing, and GM mid-adventure reframing
- Documents that GM starts with 5 Fear tokens when a new campaign begins
- Includes templates for creating custom campaign frames following SRD structure

## Changes

- `daggerheart-system/skills/dh-frame/SKILL.md` - Main skill with guidance
- `daggerheart-system/skills/dh-frame/references/frame-template.md` - Blank template for custom frames
- `daggerheart-system/skills/dh-frame/references/frame-structure.md` - Detailed section explanations
- `daggerheart-system/skills/dh-frame/references/srd` - Symlink to SRD frames
- `daggerheart-system/CLAUDE.md` - Updated plugin documentation

## Test plan

- [ ] Verify skill is discoverable via Claude Code
- [ ] Test frame-template.md can be filled in to create a valid frame
- [ ] Verify symlink to SRD frames works correctly
- [ ] Check CLAUDE.md accurately describes the new skill

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)