### PR TITLE
fix: auto-inject world art style into image generation #224

### DIFF
--- a/backend/src/gm-prompt.ts
+++ b/backend/src/gm-prompt.ts
@@ -704,7 +704,7 @@ Read relevant existing STATE files to maintain consistency:
 
 **When in doubt, call set_theme()** - multiple calls are fine, debouncing prevents spam.
 
-**Art Style**: Check ${paths.artStyle} for this world's visual style (e.g., "painterly oil painting", "pixel art 16-bit", "watercolor illustration"). If the file exists, ALWAYS include its content in the \`image_prompt\` parameter when calling set_theme. Example: if art-style.md contains "oil painting, impressionist style", your image_prompt should be: "A misty forest clearing at dawn. Oil painting, impressionist style."
+**Art Style**: The server automatically reads ${paths.artStyle} and applies it to all generated images. You don't need to include it in image_prompt—it's injected automatically. When creating a new world, write a 1-2 line art style to this file immediately (e.g., "Oil painting, impressionist brushwork, warm earth tones").
 
 **Common patterns** (use these liberally):
 - Entering tavern → set_theme(mood="calm", genre="high-fantasy", region="village")

--- a/corvran/skills/character-world-init/SKILL.md
+++ b/corvran/skills/character-world-init/SKILL.md
@@ -93,8 +93,18 @@ set_world({ name: "Eldoria", is_new: true })
 
 This creates:
 - Directory: `worlds/eldoria/`
-- Files: `world_state.md`, `locations.md`, `characters.md`, `quests.md` (with templates)
+- Files: `world_state.md`, `locations.md`, `characters.md`, `quests.md`, `art-style.md` (with templates)
 - Updates `worldRef` in adventure state to `"worlds/eldoria"`
+
+**IMPORTANT: After creating a new world, immediately write a 1-2 line art style** to `art-style.md` based on the world's genre and tone. This art style is automatically applied to all generated background images. Example:
+
+```
+# Art Style
+
+Oil painting, impressionist brushwork, warm earth tones
+```
+
+Keep it concise—just the visual style keywords, not a full description.
 
 ### To Use an Existing World
 
@@ -113,8 +123,9 @@ After creating new entries, populate the markdown files with player-provided det
 - Set initial attributes, equipment, and abilities
 - Track current location and objectives in state.md
 
-**World files** (`world_state.md`, `locations.md`, `characters.md`, `quests.md`):
-- Establish genre, era, and tone
+**World files** (`world_state.md`, `locations.md`, `characters.md`, `quests.md`, `art-style.md`):
+- Write the art style FIRST (1-2 lines, e.g., "Watercolor illustration, soft pastels, dreamlike quality")
+- Establish genre, era, and tone in world_state.md
 - Create the starting location with vivid description
 - Add initial NPCs as the player encounters them
 

--- a/corvran/skills/character-world-init/references/file-structure.md
+++ b/corvran/skills/character-world-init/references/file-structure.md
@@ -12,6 +12,7 @@ players/
 
 worlds/
   {world-slug}/
+    art-style.md     # Visual style for generated images (1-2 lines)
     world_state.md   # Current world conditions
     locations.md     # Known locations
     characters.md    # NPCs and factions
@@ -120,6 +121,44 @@ The character state tracks mutable session data: current location, conditions, a
 ```
 
 ## World Files
+
+### art-style.md
+
+The art style defines the visual aesthetic for all generated background images in this world. The server automatically applies this style to image generation prompts.
+
+```markdown
+# Art Style
+
+[1-2 line visual style description]
+```
+
+**Keep it concise.** This is appended to every image generation prompt, so use only essential style keywords.
+
+#### Examples
+
+```markdown
+# Art Style
+
+Oil painting, impressionist brushwork, warm earth tones
+```
+
+```markdown
+# Art Style
+
+Pixel art, 16-bit SNES era, vibrant colors
+```
+
+```markdown
+# Art Style
+
+Watercolor illustration, soft edges, muted pastels
+```
+
+```markdown
+# Art Style
+
+Dark fantasy digital art, dramatic lighting, Beksinski-inspired
+```
 
 ### world_state.md
 


### PR DESCRIPTION
## Summary

- Server now automatically reads `art-style.md` and injects it into all image generation prompts
- GM no longer needs to manually append art style to `image_prompt` - it happens automatically
- Updated skill documentation to emphasize writing 1-2 line art style when creating worlds

## Changes

**Backend (`game-session.ts`):**
- Added `getWorldArtStyle()` method to read and extract meaningful content from `art-style.md`
- Modified `handleSetThemeTool()` to auto-inject art style before calling background image service
- Added path traversal protection using `safeResolvePath`

**GM Prompt (`gm-prompt.ts`):**
- Updated art style instructions to explain auto-injection
- Added guidance to write 1-2 line art style when creating new worlds

**Skill Documentation (`character-world-init`):**
- Added `art-style.md` to file structure
- Added examples of concise art style formats
- Emphasized writing art style FIRST when creating a world

## Test plan

- [x] All 783 unit tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes
- [ ] Manual test: Create new world, verify art-style.md is populated
- [ ] Manual test: Set theme, verify generated images have consistent style

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)