### PR TITLE
fix: prioritize art style in image generation prompts

### DIFF
--- a/backend/src/game-session.ts
+++ b/backend/src/game-session.ts
@@ -1151,13 +1151,20 @@ export class GameSession {
     this.lastThemeChange = { mood, timestamp: now };
 
     // Inject world art style into image prompt if available
-    // This ensures consistent visual style across all generated images for a world
+    // Art style comes FIRST to set the visual tone, then scene description
     const artStyle = this.getWorldArtStyle(log);
     if (artStyle) {
+      const originalPrompt = image_prompt;
+      // Art style prefix, then scene description
       image_prompt = image_prompt
-        ? `${image_prompt}. ${artStyle}`
+        ? `${artStyle}. ${image_prompt}`
         : artStyle;
-      log.debug({ artStyle }, "Injected world art style into image prompt");
+      log.info(
+        { artStyle: artStyle.slice(0, 100), originalPrompt: originalPrompt?.slice(0, 50), finalPrompt: image_prompt.slice(0, 200) },
+        "Injected world art style as prefix"
+      );
+    } else {
+      log.debug("No art style found for world");
     }
 
     // Get background image URL using GM-provided tags for catalog lookup


### PR DESCRIPTION
## Summary
Follow-up to #234. The path validation fix was merged, but these prompt priority fixes were not:

- Art style now **prefixes** the scene description (was suffix)
- `narrativeContext` is now the **primary** prompt content, not subordinate "with context:" text

Before:
```
A tense scene. in high-fantasy style. depicting village. with context: {art style + scene}
```

After:
```
{art style}. {scene}. dramatic tension. village. Cinematic composition...
```

## Test plan
- [x] All unit tests pass
- [x] Typecheck passes
- [x] Lint passes
- [ ] Manual test: Generate image with world art style and verify style is prominent

🤖 Generated with [Claude Code](https://claude.com/claude-code)