### PR TITLE
Fix pi-agent model resolution with extension binding

### DIFF
--- a/.lore/notes/pi-agent-model-resolution-fix.md
+++ b/.lore/notes/pi-agent-model-resolution-fix.md
@@ -1,0 +1,109 @@
+---
+title: "Implementation notes: pi-agent model resolution fix"
+date: 2026-05-18
+status: in_progress
+tags: [implementation, notes, pi-agent, model-resolution]
+source: .lore/plans/pi-agent-model-resolution-fix.md
+modules: [backend]
+---
+
+# Implementation Notes: pi-agent model resolution fix
+
+## Summary
+
+Implemented across 6 autonomous phases (1+2 combined, plus 3, 4, 5, 6, and 8). Phase 7 (live smoke) is the only outstanding step and must be run by the user against their actual pi config.
+
+What landed:
+- `session-runner.ts`: stripped `MODEL_ALIASES`, `resolveModel`, `getModel` import, `modelOverride` dep, eager model resolution, and the `model` field on the runner return. Added exported `parseModelString` helper. Inside `runQuery`, deferred model lookup via `session.modelRegistry.find` runs after `bindExtensions({})`; on miss or malformed string, a warn fires and the session uses pi's registry default.
+- `app.ts`: replaced `createSummarizeFn` with a per-call bound-session factory (`SessionManager.inMemory` + `DefaultResourceLoader` with `noExtensions: false` + `createAgentSession` with `noTools: "all"` + `bindExtensions` + registry-based model resolution + abort threading with already-aborted guard + differentiated empty-response errors + unconditional dispose). Removed `?? "haiku"` / `?? "sonnet"` env defaults. Removed `completeSimple` and `resolveModel` imports.
+- `mock-session-runner.ts`: dropped the cast-through-`SessionRunner["model"]` `model:` field.
+- `CLAUDE.md`: rewrote the Architecture bullet that referenced `completeSimple` + "Haiku"; added a new bullet documenting deferred model resolution via `session.modelRegistry.find`.
+- `.lore/retros/2026-05-pi-agent-migration.md`: appended an addendum that names the lesson (static `getModel` can't see extension-registered providers; standalone `completeSimple` bypasses extension hooks).
+
+Validation: typecheck pass, lint pass (one in-flight fix for `@typescript-eslint/no-floating-promises` on `session.abort()`), 658/658 tests pass.
+
+Plan-reviewer (Phase 8) flagged one important live-smoke question: the GM runner's `DefaultResourceLoader` still uses `noExtensions: true`. If that flag prevents `pi-fallback-provider` from populating the session's `modelRegistry`, the GM surface is still broken despite the resolution code being correct. The compaction surface uses `noExtensions: false` explicitly. Phase 7 is the only thing that can resolve this.
+
+No divergences from the plan. One minor mechanical decision: combined Phase 1+2 into a single dispatch because Step 1 alone leaves a knowingly broken intermediate state that Step 2 immediately fixes.
+
+## Progress
+
+- [x] Phase 1: Strip alias scheme from session-runner + mock
+- [x] Phase 2: Add deferred model resolution inside runQuery
+- [x] Phase 3: Build bound-session summarize fn for compaction (preceded by design review)
+- [x] Phase 4: Update app.ts wiring to pass-through optional config
+- [x] Phase 5: Update CLAUDE.md + add retro addendum
+- [x] Phase 6: typecheck + lint + tests
+- [ ] Phase 7: Live smoke (manual, surfaced to user)
+- [x] Phase 8: Validate via plan-reviewer
+
+## Log
+
+### Context gathered (pre-phase)
+
+Prior work surfaced via lore-researcher:
+- `.lore/retros/2026-05-pi-agent-migration.md` — risks 1 and 3 are exactly what this plan closes.
+- `.lore/reference/architecture-pattern.md` — stale (still says "Hard Constraint: Claude Agent SDK Only"). Plan flags it; do not consult for SDK constraints.
+- `.lore/specs/compaction-system.md` REQ-COMP-9a — preserves `COMPACTION_MODEL` env contract (default was `"haiku"`, the plan removes that fallback intentionally).
+- Memory `feedback_provider_neutrality.md` — load-bearing rule: never `getModel("anthropic", ...)`; resolve via `session.modelRegistry.find` post-`bindExtensions`; on miss, leave session at registry default.
+- Memory `feedback_review_before_documenting.md` — pause before propagating patterns from this fix into reference docs.
+
+Source files inspected:
+- `packages/backend/src/services/session-runner.ts` (302 lines)
+- `packages/backend/src/app.ts` (224 lines)
+- `packages/backend/src/services/compaction-service.ts` (215 lines)
+- `packages/backend/tests/helpers/mock-session-runner.ts` (104 lines)
+
+No project agent registry — using `general-purpose` for impl/test/review, and the named `lore-development:design-reviewer` / `lore-development:plan-reviewer` agents the plan explicitly calls for.
+
+### Phase 1+2: session-runner refactor
+
+- Dispatched: combined Steps 1 and 2 into one general-purpose agent dispatch. Step 1 alone leaves the file knowingly broken; combining avoids a dead test cycle.
+- Result: clean. `MODEL_ALIASES`, `resolveModel`, `AnyModel`, `ProviderKey`, `ModelIdKey`, `getModel`, `modelOverride` all removed. `parseModelString` exported (per plan, for Phase 3 reuse). Mock updated.
+- Tests: skipped per orchestrator decision — intermediate state has known type errors in `app.ts` from orphaned `resolveModel` import; clears in Phase 4. Full validation at Phase 6.
+- Minor mechanical: agent split `ImageContent`/`TextContent` into a pure `import type` line. Same behavior, cleaner.
+
+### Phase 8: plan-reviewer
+
+- Dispatched: `lore-development:plan-reviewer` against the plan + the five changed files.
+- Verdict: **Sound** with one important live-smoke question.
+- Important: GM runner uses `noExtensions: true` on its `DefaultResourceLoader` (session-runner.ts:177) while compaction uses `noExtensions: false`. The reviewer cannot resolve from source whether pi's `bindExtensions` still queues provider hooks under `noExtensions: true`. If it does not, surface 1 (GM loop) is still broken despite the deferred-resolution code being correct. Live smoke (Phase 7) catches this. If broken, flip the GM loader flag to `noExtensions: false` and verify other suppression (`noSkills`, `noPromptTemplates`, etc.) still does the work.
+- Minor (fixed): retro addendum claimed risk 1 was closed by the code change. Retitled — risk 3 closed by code; risk 1 addressed-but-requires-smoke.
+- Optional (deferred): one-line comment in `createSummarizeFn` explaining the abort-listener-after-model-resolution sequencing. Default no-comment rule applies; user can add if they want.
+
+### Phase 6: validate
+
+- Typecheck: pass.
+- Lint (first pass): one new violation — `@typescript-eslint/no-floating-promises` on `session.abort()` in the already-aborted guard branch in app.ts:180 (the in-block sibling of the closure-internal `void session.abort()` seven lines above). Fixed by mirroring the `void` prefix.
+- Lint (second pass): pass. Only pre-existing warnings in web/ unrelated to this work.
+- Tests: 658/658 pass.
+
+### Phase 5: CLAUDE.md + retro addendum
+
+- Dispatched: general-purpose agent. CLAUDE.md's stale Architecture bullet (mentioned `completeSimple` and "Haiku") rewritten; new bullet added for deferred model resolution. Retro addendum appended at the bottom; closes risks 1 and 3 of the original retro.
+- Per `feedback_review_before_documenting` memory: `.lore/reference/architecture-pattern.md` and `.lore/specs/compaction-system.md` left alone — they're stale but the plan defers their rewrite, and the user should review the code before reference docs get rewritten on top of it.
+
+### Phase 4: app.ts wiring
+
+- Dispatched: general-purpose agent. Removed `?? "haiku"` and `?? "sonnet"` defaults; `compactionModel` and `gmModel` are now `string | undefined`. Passed `process.cwd()` to `createSummarizeFn`. Updated AppDeps JSDoc to drop "alias" framing.
+- Result: clean. No Anthropic-shaped string literals remain in app.ts. `noAi` test path untouched.
+
+### Phase 3: implementation
+
+- Dispatched: general-purpose agent with the three design-review refinements baked in.
+- Verification result: pi-coding-agent 0.75.1 types `noTools?: "all" | "builtin"`. `"all"` is the documented value for "start with no tools enabled" while still loading extensions. Plan was correct.
+- Result: clean. `createSummarizeFn(modelString, cwd)` builds a per-call in-memory bound session with `noExtensions: false` (extensions load), `noTools: "all"` (no tool surface), `systemPrompt` threaded via loader, model resolution post-`bindExtensions`, abort listener guarded with already-aborted check, three differentiated empty-response error messages, unconditional `dispose()` in finally.
+- Known follow-up: call site still calls `createSummarizeFn(compactionModel)` with one arg — type error until Phase 4.
+
+### Phase 3: design review (pre-implementation)
+
+- Dispatched: lore-development:design-reviewer against Step 3 only, focused on lifecycle hazards.
+- Findings (3 real, 4 non-issues):
+  1. Verify `noTools: "all"` is a valid typed value; fall back to `tools: []` if not.
+  2. Declare `onAbort` outside try; guard removal in finally; add already-aborted check after listener registration.
+  3. Distinguish empty-response failure modes (no messages / no text blocks / empty content) for forensics.
+- Resolution: baked all three into the implementation prompt.
+
+## Divergence
+
+(empty)

--- a/.lore/notes/simplify-pi-agent-model-resolution-fix.md
+++ b/.lore/notes/simplify-pi-agent-model-resolution-fix.md
@@ -1,0 +1,41 @@
+---
+title: "Simplification notes: pi-agent model resolution fix"
+date: 2026-05-18
+status: in_progress
+tags: [simplify, cleanup, code-quality, pi-agent]
+modules: [backend]
+---
+
+# Simplification Notes: pi-agent model resolution fix
+
+Resumed from `.lore/notes/pi-agent-model-resolution-fix.md`. Targeting only TS source files; the two doc files (CLAUDE.md, retro addendum) are intentionally phrased and not simplify candidates.
+
+## Files Processed
+
+- packages/backend/src/services/session-runner.ts
+- packages/backend/src/app.ts
+- packages/backend/tests/helpers/mock-session-runner.ts
+
+## Cleanup Agents Run
+
+- general-purpose (acting as code-simplifier — `code-simplifier:code-simplifier` not installed)
+
+## Results
+
+### Simplification
+
+- Agent: general-purpose (as code-simplifier)
+  Changes: Extracted `toFriendlyError(message)` helper in session-runner.ts beside `isContextOverflowError` and replaced two identical inline ternaries in the runQuery try/catch. Fixed stale `AppDeps.compactionService` doc comment in app.ts that still claimed "built using pi-ai's completeSimple". Mock unchanged.
+  Rejected (with reasons): factoring shared parseModelString resolution block (parity is intentional per hard constraint), tightening `formatToolResultForClient` cast (would just shuffle text), inlining `parseModelString` (kept exported for app.ts), collapsing `??`-style null coalesce (would change behavior on empty string), flattening mock's `calls.push({...})` (tests read its public surface).
+
+### Testing
+
+(pending)
+
+### Review
+
+(pending)
+
+## Failures
+
+(empty)

--- a/.lore/plans/pi-agent-model-resolution-fix.md
+++ b/.lore/plans/pi-agent-model-resolution-fix.md
@@ -1,0 +1,262 @@
+---
+title: "Implementation plan: pi-agent model resolution fix"
+date: 2026-05-18
+status: draft
+tags: [plan, pi-agent, model-resolution, compaction, provider-neutrality]
+modules: [backend]
+related: [.lore/retros/2026-05-pi-agent-migration.md]
+---
+
+# Plan: pi-agent model resolution fix
+
+## Goal
+
+Make Adventure Engine model resolution respect the user's pi-agent provider config — including extension-registered providers like `pi-fallback-provider` and `~/.pi/agent/settings.json` defaults — instead of hardcoding Anthropic aliases at startup. Two surfaces are wrong today and need separate fixes:
+
+1. **GM session-runner** resolves a model eagerly via static `getModel("anthropic", ...)` at runner-construction time. The static API only sees compile-time-known built-in models, so extension-registered providers are invisible. The migration guide gotcha #5 spells out that `session.modelRegistry.find` post-`bindExtensions` is the only correct path.
+2. **Compaction service** calls `completeSimple(model, ...)` standalone outside any bound session. Per migration guide gotcha #4, this bypasses every extension hook — including `pi-fallback-provider`'s `streamSimple` wrapper — so the user's fallback routing never applies to summarization even if we fixed (1).
+
+Success looks like: a user with `defaultProvider: "fallback"` and the `pi-fallback-provider` extension can run both a GM turn and a compaction without any Anthropic-specific config, and both calls route through the fallback provider's hooks. A user who explicitly configures `MODEL=openrouter/some-model` and `COMPACTION_MODEL=openai/gpt-5` gets exactly those providers, with a console warning + sensible fallback if a configured model isn't in the registry.
+
+## Codebase Context
+
+**The three sites that need to change**:
+
+- `packages/backend/src/services/session-runner.ts:30-63` — `MODEL_ALIASES` table, `resolveModel`, `ProviderKey`/`ModelIdKey` casts, and the eager `resolveModel(config.model)` in `createSessionRunner` (line 156). The runner's return object exposes a `model` field that is no longer meaningful once resolution is deferred to `runQuery`.
+- `packages/backend/src/app.ts:91-114` — `createSummarizeFn(modelString)` builds a `Model` once via `resolveModel` and captures it in closure. The closure body calls `completeSimple(model, ...)` directly — no bound session, no extension hooks.
+- `packages/backend/src/services/compaction-service.ts` — `SummarizeFn(systemPrompt, text, signal) → string` contract is fine as-is. Only the production wiring needs to change; the service itself is decoupled from how the model is resolved or called.
+
+**Reference pattern** (oracle-keep, `/home/rjroy/Projects/oracle-keep/lib/session.ts:49-57, 110-130`):
+
+```ts
+function parseModelString(s: string): { provider: string; modelId: string } | null {
+  if (!s) return null;
+  const slash = s.indexOf("/");
+  if (slash === -1) return null;
+  return { provider: s.slice(0, slash), modelId: s.slice(slash + 1) };
+}
+
+// post-bindExtensions:
+const parsed = parseModelString(config.model);
+if (parsed) {
+  const model = session.modelRegistry.find(parsed.provider, parsed.modelId);
+  if (model) await session.setModel(model);
+  else console.warn(`model "${config.model}" not found in registry, using session default`);
+}
+```
+
+The "no model configured" path (parsed is null) skips `setModel` entirely; the session uses whatever `~/.pi/agent/settings.json` resolves to (in this user's case, `fallback/basic`).
+
+**Test surface**:
+
+- `packages/backend/tests/services/compaction-service.test.ts` — passes `summarize: SummarizeFn` stubs directly. Unaffected.
+- `packages/backend/tests/routes/compact-endpoint.test.ts` — passes `summarize` stubs. Unaffected.
+- `packages/backend/tests/routes/message-threshold.test.ts` — same. Unaffected.
+- `packages/backend/tests/message-route.test.ts` — uses `createMockSessionRunner`, never touches the real session-runner. Unaffected.
+- `packages/backend/tests/adventure-creation.test.ts`, `system-routes.test.ts` — use `createApp({ noAi: true })`. Unaffected.
+- `tests/mock-sdk-integration.test.ts` — injects a mock SessionRunner. Unaffected.
+
+The real session-runner has **no direct unit tests**. It's covered transitively through `mock-sdk-integration` (mock runner) and live smoke. This is a gap, but introducing tests for it here would couple to pi-agent internals; punt to a follow-up issue.
+
+**Out of scope for this plan** (call out for back-propagation later):
+
+- `.lore/reference/architecture-pattern.md` — still mandates claude-agent-sdk. Stale since the migration commit.
+- `.lore/specs/compaction-system.md` REQ-COMP-9a and REQ-COMP-25 — still talk about `QueryFn` and SDK options. Stale.
+- `.lore/retros/2026-05-pi-agent-migration.md` — documents the alias scheme this plan is removing. After this plan executes, the retro needs an addendum.
+
+## Implementation Steps
+
+### Step 1: Strip the alias scheme from session-runner (and its mock)
+
+**Files**: `packages/backend/src/services/session-runner.ts`, `packages/backend/tests/helpers/mock-session-runner.ts`
+**Expertise**: none
+
+In `session-runner.ts`, remove:
+- The `MODEL_ALIASES` table (lines 30-35).
+- `resolveModel` function (lines 42-63).
+- The `AnyModel`, `ProviderKey`, `ModelIdKey` type aliases (lines 14-17, 37-40).
+- The `getModel` import from `@earendil-works/pi-ai`.
+- The `modelOverride?: AnyModel` field on `createSessionRunner`'s deps.
+- The `const model = deps.modelOverride ?? resolveModel(config.model);` line in `createSessionRunner`.
+- The `model` field on the runner's return value.
+
+`modelOverride` is safe to drop without replacement: every real-runner test path uses `createMockSessionRunner` rather than the real `createSessionRunner`, and once resolution is deferred into `runQuery` against a live pi session, there is no construction-time injection point that could be meaningful.
+
+Keep `ImageContent`, `TextContent` imports — still used by `formatToolResultForClient`.
+
+Change `SessionRunnerConfig` to:
+
+```ts
+export interface SessionRunnerConfig {
+  /** Optional "provider/modelId" string. When omitted, the session uses pi's settings default. */
+  model?: string;
+}
+```
+
+`createSessionRunner`'s return becomes `{ runQuery }` (no `model`).
+
+In `mock-session-runner.ts`:
+- Drop the `model: ...` field on the returned object (line 98 — currently casts a stub through `SessionRunner["model"]`, which becomes a compile error the moment `model` is removed from the source type).
+- Drop any field-by-field references on `MockSessionRunner`; the `extends SessionRunner` clause already inherits the new shape.
+
+Without this, all 658 tests fail to compile.
+
+### Step 2: Add deferred model resolution inside runQuery
+
+**Files**: `packages/backend/src/services/session-runner.ts`
+**Expertise**: none
+
+Add a private helper near the top of the file:
+
+```ts
+function parseModelString(s: string | undefined): { provider: string; modelId: string } | null {
+  if (!s) return null;
+  const slash = s.indexOf("/");
+  if (slash === -1) return null;
+  return { provider: s.slice(0, slash), modelId: s.slice(slash + 1) };
+}
+```
+
+In `runQuery`, between `await session.bindExtensions({})` and any other use of the session, do the registry lookup:
+
+```ts
+await session.bindExtensions({});
+
+const parsed = parseModelString(config.model);
+if (parsed) {
+  const model = session.modelRegistry.find(parsed.provider, parsed.modelId);
+  if (model) {
+    await session.setModel(model);
+  } else {
+    console.warn(
+      `[session-runner] model "${config.model}" not found in registry, using session default`,
+    );
+  }
+} else if (config.model) {
+  // Set but malformed (no slash) — log and fall through to default.
+  console.warn(
+    `[session-runner] model "${config.model}" is malformed (expected "provider/modelId"), using session default`,
+  );
+}
+```
+
+Remove the existing `await session.setModel(model)` line that ran after `bindExtensions`. If no model is configured or it doesn't resolve, the session stays at registry default (which respects `~/.pi/agent/settings.json`'s `defaultProvider`/`defaultModel`, including the user's `fallback/basic`).
+
+### Step 3: Build a bound-session summarize fn for compaction
+
+**Files**: `packages/backend/src/app.ts`
+**Expertise**: pi-agent integration knowledge — fresh eyes worth getting on lifecycle (AbortSignal threading, dispose ordering, per-call cost in steady state). See Delegation Guide.
+
+Behavioral facts to lean on (confirmed against the user's hands-on pi experience, not just docs):
+- A session whose `setModel` is never called uses pi's `~/.pi/agent/settings.json` `defaultProvider`/`defaultModel` (the user's `fallback/basic`) once `bindExtensions` runs.
+- `noExtensions: false` + `noTools: "all"` is a valid combination: extensions that register tools are loaded but their tools are not surfaced to the agent. Hooks like `pi-fallback-provider`'s `streamSimple` wrapper still fire.
+
+Replace `createSummarizeFn(modelString: string): SummarizeFn` with a new factory that builds a fresh bound session per call. The session is purpose-built for one-shot summarization: no tools, fresh in-memory session, extensions enabled so `pi-fallback-provider`'s `streamSimple` hook fires.
+
+New signature:
+
+```ts
+function createSummarizeFn(
+  modelString: string | undefined,
+  cwd: string,
+): SummarizeFn
+```
+
+Body (per `summarize` call):
+
+1. Build a `SessionManager.inMemory(cwd)`.
+2. Build a `DefaultResourceLoader({ cwd, agentDir: getAgentDir(), systemPrompt, noExtensions: false, noSkills: true, noPromptTemplates: true, noThemes: true, noContextFiles: true })`. Note: `noExtensions: false` (we want the fallback-provider extension to load). Pass the per-call `systemPrompt` directly so the loader uses it verbatim.
+3. `await loader.reload()`.
+4. `await createAgentSession({ cwd, resourceLoader: loader, sessionManager: manager, noTools: "all" })`. `noTools: "all"` keeps the agent from calling anything — this is a single-turn text-out call.
+5. `await session.bindExtensions({})`.
+6. Resolve model: same `parseModelString` + `session.modelRegistry.find` pattern as Step 2. Skip `setModel` on miss, warn.
+7. Wire abort: if the caller's `signal` aborts, call `session.abort()`. Remove the listener in the finally block.
+8. Subscribe long enough to detect errors via `session.agent.state.errorMessage` after `agent_end` (mirroring session-runner's pattern). Capture the final assistant text from `session.messages` after `prompt` resolves.
+9. `await session.prompt(text)` — `text` is the content being summarized; `systemPrompt` is already on the loader.
+10. Extract the last assistant message's text content from `session.messages` (filter `{type: "text"}` blocks, join). Throw if empty.
+11. `session.dispose()` in finally.
+
+Reuse the `parseModelString` helper from session-runner by exporting it from there (or duplicating — duplicating is fine since it's three lines; export is cleaner).
+
+Cost: one `createAgentSession` + `bindExtensions` + `prompt` + `dispose` per compaction. Compaction fires on threshold crossings or explicit `/compact` calls — rare per adventure, not per message. Acceptable.
+
+### Step 4: Update app.ts wiring to pass-through optional config
+
+**Files**: `packages/backend/src/app.ts`
+**Expertise**: none
+
+Changes:
+
+- Drop the `resolveModel` import from `./services/session-runner`.
+- `gmModel: string | undefined = deps?.model ?? process.env.MODEL` (no `?? "sonnet"` fallback). Pass to `createSessionRunner({ config: { model: gmModel } })`. If undefined, the runner uses the session's registry-default.
+- `compactionModel: string | undefined = deps?.compactionModel ?? process.env.COMPACTION_MODEL` (no `?? "haiku"` fallback).
+- `createSummarizeFn(compactionModel, cwd)` — pass `cwd` so the compaction session has a working directory. Use `adventuresPath` or `process.cwd()` — pick `process.cwd()` since compaction doesn't run per-adventure-cwd in the production wiring (cwd here is just for session bookkeeping, not file resolution).
+- The `AppDeps` interface keeps `model?: string` and `compactionModel?: string` — both already optional.
+
+The `noAi: true` test path still skips both factories entirely. No test changes needed.
+
+### Step 5: Update CLAUDE.md + add retro addendum
+
+**Files**: `CLAUDE.md`, `.lore/retros/2026-05-pi-agent-migration.md`
+**Expertise**: none
+
+`CLAUDE.md`'s "Architecture" section currently doesn't mention model resolution. Add one line:
+
+> Model selection is deferred to `session.modelRegistry.find` after `bindExtensions` so extension-registered providers (`pi-fallback-provider`, etc.) are visible. Configure via `MODEL=provider/modelId` and `COMPACTION_MODEL=provider/modelId`; omit to use pi's settings default.
+
+`.lore/retros/2026-05-pi-agent-migration.md` — add a short addendum at the bottom under a new `## Addendum 2026-05-18: alias scheme reverted` heading. Two-line shape, but carry the lesson, not just the change: the `MODEL_ALIASES` + static `getModel` path was wrong because the static API only sees compile-time-known built-in models — it cannot see extension-registered providers like `pi-fallback-provider`, which is the whole point of pi's provider abstraction. Same with standalone `completeSimple`: bypasses extension hooks. Fix per `.lore/plans/pi-agent-model-resolution-fix.md`.
+
+### Step 6: Lint + typecheck + test
+
+**Files**: none (validation)
+**Expertise**: none
+
+Run in order:
+
+1. `bun run typecheck` — must pass. The optional `model: string` on `SessionRunnerConfig` may surface call sites that assumed it was required.
+2. `bun run lint` — must pass. Removing the `Model<never>` aliases should reduce `no-explicit-any` pressure, not add to it.
+3. `bun test` — all 658 tests must still pass. Test surface is unchanged because mocks are used everywhere the runner is exercised.
+
+If tests fail, do not bypass — the test injection points were specifically designed to survive this kind of refactor.
+
+### Step 7: Live smoke (manual)
+
+**Files**: none (validation, manual)
+**Expertise**: deployment/runtime knowledge of pi config
+
+After CI passes, manually verify both paths against the user's actual pi config (`defaultProvider: "fallback"`, `pi-fallback-provider` extension):
+
+1. **GM turn**: `bun run dev`, create an adventure, send a message. Expect: response streams through. Watch logs for "model not found" warnings — there should be none if the `MODEL` env var is omitted or set to a model the fallback provider routes.
+2. **Compaction**: write ~150k of text into an adventure's `history.md`, send a message. Expect: a `compacted` SSE event fires before the GM response. The summarize call should route through `pi-fallback-provider`. Watch logs for the same warning class.
+3. **Explicit non-Anthropic model**: set `MODEL=openrouter/openrouter/free` (or another model the user has configured), restart, repeat (1). Expect: requests route through OpenRouter, not Anthropic.
+
+This is the validation step from this plan's perspective. The migration retro's "live smoke test follow-up" item gets closed by this.
+
+### Step 8: Validate Against Goal
+
+**Files**: none (validation)
+**Expertise**: fresh context
+
+Launch the `plan-reviewer` agent against this plan after Step 6 passes. The reviewer reads only this plan + the goal section + the modified files, and checks:
+
+- Provider neutrality: no Anthropic-specific paths remain in production code (test fixtures may still reference Anthropic for cost-of-rewrite reasons — that's fine).
+- Both surfaces (GM + compaction) route through bound sessions with extension hooks active.
+- The "warn and fall back" behavior is implemented identically for both surfaces.
+- No new architectural assumptions introduced that weren't in the goal.
+
+This is not optional. The migration commit shipped the bug that this plan fixes; the same context curse could let a re-introduction slip past me.
+
+## Delegation Guide
+
+- **Step 3 (bound-session summarize fn)**: the architectural risk lives here. Worth a fresh-eyes review *before* implementation — invoke `lore-development:design-reviewer` with the Step 3 description, asking whether the per-call session-build pattern has lifecycle hazards (resource leaks, extension state across calls, dispose ordering).
+- **Step 8 (post-implementation review)**: `lore-development:plan-reviewer` against the saved plan, then a fresh `lore-development:fresh-lore` pass on the diff to catch what the implementer missed.
+
+No security-sensitive paths; no frontend work; no performance hot path beyond "compaction does an extra session build" which is acceptable.
+
+## Open Questions
+
+These are explicitly **deferred** — not blockers for this plan:
+
+- **Lore back-propagation**: `.lore/reference/architecture-pattern.md` and `.lore/specs/compaction-system.md` (REQ-COMP-9a, REQ-COMP-25) are stale after this plan executes. File a follow-up using `lore-development:back-propagate` or `lore-development:file-issue` after merge.
+- **Direct unit tests for session-runner**: currently exercised only through mocks + live smoke. Worth a follow-up issue to add coverage that doesn't couple to pi internals (e.g. parseModelString as a pure function, the warn-on-miss path with a stub registry).
+- **Compaction session reuse**: if per-call session-build becomes a measurable latency problem in practice, revisit option (B) from the design discussion (cached singleton). Don't optimize speculatively.

--- a/.lore/retros/2026-05-pi-agent-migration.md
+++ b/.lore/retros/2026-05-pi-agent-migration.md
@@ -37,3 +37,7 @@ User-driven move toward the pi tooling family. Pi gives us provider flexibility 
 - `tests/helpers/mock-session-runner.ts` — script-based SessionRunner stub
 - `tests/helpers/invoke-tool.ts` — invokes pi `ToolDefinition.execute` for unit tests
 - Removed `tests/helpers/mock-query.ts` (SDK-coupled)
+
+## Addendum 2026-05-18: alias scheme reverted
+
+The `MODEL_ALIASES` table and the eager `getModel("anthropic", ...)` call in the session runner have been removed, along with the standalone `completeSimple` call in the compaction summarize fn. Both paths bypassed the very abstraction pi exists to provide: extension-registered providers like `pi-fallback-provider` live in the session's `modelRegistry` after `bindExtensions()`, not in the compile-time-known type parameters that `getModel` is generic over. Standalone `completeSimple` skips extension hooks entirely. Both are now resolved via `session.modelRegistry.find` on a bound session post-`bindExtensions`, mirroring the oracle-keep pattern. Fix per `.lore/plans/pi-agent-model-resolution-fix.md`. Risk 3 is closed by the fix; risk 1 is addressed by the fix but closure requires live smoke (plan Step 7) — the GM runner's loader still uses `noExtensions: true`, and only a live run with `defaultProvider: "fallback"` confirms that extension provider registration still survives that flag. Risks 2 (skill bloat) and 4 (plugin paths) remain open.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,12 @@ Monorepo with three packages: `packages/shared`, `packages/backend`, `packages/w
 ## Architecture
 
 - Daemon-first: the backend is the application, web is just a client
-- AI interaction goes through `@earendil-works/pi-coding-agent` for the streaming GM loop and `@earendil-works/pi-ai` (`completeSimple`) for out-of-loop Haiku summarization. No direct provider SDK use.
+- AI interaction goes through `@earendil-works/pi-coding-agent` for both the streaming GM loop and out-of-loop summarization. Summarization builds a fresh bound session per call so extension hooks (e.g. `pi-fallback-provider`'s `streamSimple`) apply.
 - Route/service split with DI factories (see `.lore/reference/architecture-pattern.md`)
 - The `SessionRunner` interface is event-callback shaped (`onTextDelta`/`onToolUse`/`onDone`/`onError`), not iterator-shaped — see `services/session-runner.ts`. Tests inject `createMockSessionRunner(script)`.
 - The compaction service depends on a `SummarizeFn` (text in, text out), not on any agent loop. Tests inject a stub directly.
 - Shared Zod schemas in `@corvran/shared`, imported by both backend and web. Custom tool input schemas live in pi-agent's `typebox`.
+- Model selection is deferred to `session.modelRegistry.find` after `bindExtensions` so extension-registered providers are visible. Configure via `MODEL=provider/modelId` and `COMPACTION_MODEL=provider/modelId`; omit either to use pi's settings default (`~/.pi/agent/settings.json`).
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "workspaces": ["packages/*"],
   "scripts": {
     "daemon": "bun run packages/backend/src/index.ts",
-    "dev": "concurrently -n daemon,web -c blue,green \"bun run daemon\" \"bun run --filter '@corvran/web' dev\"",
+    "dev": "concurrently --raw -n daemon,web -c blue,green \"bun run daemon\" \"cd packages/web && bun run dev\"",
     "build": "bun run typecheck && bun run --filter '@corvran/web' build",
-    "start": "concurrently -n daemon,web -c blue,green \"bun run daemon\" \"bun run --filter '@corvran/web' start\"",
+    "start": "concurrently --raw -n daemon,web -c blue,green \"bun run daemon\" \"cd packages/web && bun run start\"",
     "postinstall": "bunx tsc --build",
     "typecheck": "bunx tsc --build",
     "lint": "bun run --filter '@corvran/shared' lint && bun run --filter '@corvran/backend' lint && bun run --filter '@corvran/web' lint"

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -3,7 +3,12 @@ import { cors } from "hono/cors";
 import { resolve } from "node:path";
 import { readdir, readFile as fsReadFile, writeFile as fsWriteFile, appendFile as fsAppendFile, stat, mkdir, unlink } from "node:fs/promises";
 import { dirname } from "node:path";
-import { completeSimple } from "@earendil-works/pi-ai";
+import {
+  DefaultResourceLoader,
+  SessionManager,
+  createAgentSession,
+  getAgentDir,
+} from "@earendil-works/pi-coding-agent";
 import type { FileOps, RouteModule } from "./types";
 import { createAdventureService } from "./services/adventure-service";
 import { createAdventureRoutes } from "./routes/adventure-routes";
@@ -12,7 +17,7 @@ import { createHelpRoutes } from "./registry";
 import { createHistoryService } from "./services/history-service";
 import {
   createSessionRunner,
-  resolveModel,
+  parseModelString,
   type SessionRunner,
 } from "./services/session-runner";
 import type { PluginRegistry } from "./services/plugin-registry";
@@ -101,37 +106,104 @@ export interface AppDeps {
   adventuresPath?: string;
   /** Pre-built session runner. When omitted, one is built using the production pi-agent path. */
   sessionRunner?: SessionRunner;
-  /** Pre-built compaction service. When omitted, one is built using pi-ai's completeSimple. */
+  /** Pre-built compaction service. When omitted, one is built using a per-call bound pi-agent session. */
   compactionService?: CompactionService;
-  /** Default model alias or "provider/modelId" for the GM agent. */
+  /** Optional "provider/modelId" for the GM agent. When omitted, pi's settings default is used. */
   model?: string;
-  /** Default model alias or "provider/modelId" for compaction summarization. */
+  /** Optional "provider/modelId" for compaction summarization. When omitted, pi's settings default is used. */
   compactionModel?: string;
   /** Disable AI integration entirely (no session runner, no compaction). */
   noAi?: boolean;
   pluginRegistry?: PluginRegistry;
 }
 
-/** Production summarize fn backed by pi-ai's completeSimple. One-shot LLM call. */
-function createSummarizeFn(modelString: string): SummarizeFn {
-  const model = resolveModel(modelString);
+/**
+ * Production summarize fn backed by a fresh bound pi-agent session per call.
+ *
+ * Building a session (rather than calling pi-ai's `completeSimple` directly)
+ * routes the call through `bindExtensions`, so extension-registered providers
+ * such as `pi-fallback-provider`'s `streamSimple` hook actually fire. Model
+ * resolution is deferred to post-`bindExtensions` against the live registry,
+ * matching the GM session-runner. When `modelString` is undefined, the session
+ * uses pi's registry-default model from `~/.pi/agent/settings.json`.
+ */
+function createSummarizeFn(
+  modelString: string | undefined,
+  cwd: string,
+): SummarizeFn {
   return async ({ systemPrompt, text, signal }) => {
-    const message = await completeSimple(
-      model,
-      {
-        systemPrompt,
-        messages: [{ role: "user", content: text, timestamp: Date.now() }],
-      },
-      { signal },
-    );
-    const out = message.content
-      .filter((c): c is { type: "text"; text: string } => c.type === "text")
-      .map((c) => c.text)
-      .join("");
-    if (!out) {
-      throw new Error("Summarization returned no text content");
+    const manager = SessionManager.inMemory(cwd);
+    const loader = new DefaultResourceLoader({
+      cwd,
+      agentDir: getAgentDir(),
+      systemPrompt,
+      noExtensions: false,
+      noSkills: true,
+      noPromptTemplates: true,
+      noThemes: true,
+      noContextFiles: true,
+    });
+    await loader.reload();
+
+    const { session } = await createAgentSession({
+      cwd,
+      resourceLoader: loader,
+      sessionManager: manager,
+      noTools: "all",
+    });
+
+    let onAbort: (() => void) | undefined;
+    try {
+      await session.bindExtensions({});
+
+      const parsed = parseModelString(modelString);
+      if (parsed) {
+        const model = session.modelRegistry.find(parsed.provider, parsed.modelId);
+        if (model) {
+          await session.setModel(model);
+        } else {
+          console.warn(
+            `[summarize] model "${modelString}" not found in registry, using session default`,
+          );
+        }
+      } else if (modelString) {
+        console.warn(
+          `[summarize] model "${modelString}" is malformed (expected "provider/modelId"), using session default`,
+        );
+      }
+
+      onAbort = () => {
+        void session.abort();
+      };
+      signal.addEventListener("abort", onAbort);
+      if (signal.aborted) {
+        void session.abort();
+      }
+
+      await session.prompt(text);
+
+      const assistantMessages = session.messages.filter((m) => m.role === "assistant");
+      const last = assistantMessages[assistantMessages.length - 1];
+      if (!last) {
+        throw new Error("Summarization produced no assistant message");
+      }
+      const textBlocks = last.content.filter(
+        (c): c is { type: "text"; text: string } => c.type === "text",
+      );
+      if (textBlocks.length === 0) {
+        throw new Error("Summarization response contained no text content");
+      }
+      const out = textBlocks.map((c) => c.text).join("");
+      if (out === "") {
+        throw new Error("Summarization returned empty text");
+      }
+      return out;
+    } finally {
+      if (onAbort) {
+        signal.removeEventListener("abort", onAbort);
+      }
+      session.dispose();
     }
-    return out;
   };
 }
 
@@ -144,8 +216,8 @@ export function createApp(deps?: AppDeps): Hono {
   const adventureService = createAdventureService({ fileOps, adventuresPath });
   const historyService = createHistoryService({ fileOps });
 
-  const compactionModel = deps?.compactionModel ?? process.env.COMPACTION_MODEL ?? "haiku";
-  const gmModel = deps?.model ?? process.env.MODEL ?? "sonnet";
+  const compactionModel: string | undefined = deps?.compactionModel ?? process.env.COMPACTION_MODEL;
+  const gmModel: string | undefined = deps?.model ?? process.env.MODEL;
 
   // Production wiring: build compaction + session runner from the pi-agent path.
   // Tests inject `noAi: true` to skip AI integration entirely, or pass pre-built
@@ -154,7 +226,7 @@ export function createApp(deps?: AppDeps): Hono {
   if (!compactionService && !deps?.noAi) {
     compactionService = createCompactionService({
       fileOps,
-      summarize: createSummarizeFn(compactionModel),
+      summarize: createSummarizeFn(compactionModel, process.cwd()),
     });
   }
 

--- a/packages/backend/src/services/session-runner.ts
+++ b/packages/backend/src/services/session-runner.ts
@@ -11,10 +11,7 @@ import {
   type Skill,
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
-import { getModel, type ImageContent, type Model, type TextContent } from "@earendil-works/pi-ai";
-
-/** Any pi-ai Model — the api type parameter is irrelevant to this codebase. */
-type AnyModel = Model<never>;
+import type { ImageContent, TextContent } from "@earendil-works/pi-ai";
 import type { MoodState } from "@corvran/shared";
 import { createDiceToolDef } from "./dice-tool";
 import { createMoodToolDef, type MoodEventPayload } from "./mood-tool";
@@ -27,44 +24,20 @@ import { extractDominantHue } from "./color-extract";
 /** Built-in pi tools the GM agent is allowed to call. */
 const ALLOWED_BUILTIN_TOOLS = ["bash", "read", "write", "edit", "grep", "find", "ls"];
 
-/** Map terse model aliases to pi-ai provider+modelId pairs. */
-const MODEL_ALIASES: Record<string, { provider: string; modelId: string }> = {
-  sonnet: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
-  haiku: { provider: "anthropic", modelId: "claude-haiku-4-5" },
-  opus: { provider: "anthropic", modelId: "claude-opus-4-7" },
-};
-
-// getModel is generic over compile-time-known provider/model keys. We accept
-// dynamic strings at runtime, so cast through these aliases at the call site.
-type ProviderKey = Parameters<typeof getModel>[0];
-type ModelIdKey<P extends ProviderKey> = Parameters<typeof getModel<P, never>>[1];
-
-export function resolveModel(modelString: string): AnyModel {
-  // Accept either an alias ("sonnet") or "provider/modelId" form.
-  const alias = MODEL_ALIASES[modelString];
-  if (alias) {
-    return getModel(
-      alias.provider as ProviderKey,
-      alias.modelId as ModelIdKey<ProviderKey>,
-    ) as AnyModel;
-  }
-  const slash = modelString.indexOf("/");
-  if (slash === -1) {
-    throw new Error(
-      `Unknown model "${modelString}". Use an alias (sonnet, haiku, opus) or "provider/modelId".`,
-    );
-  }
-  const provider = modelString.slice(0, slash);
-  const modelId = modelString.slice(slash + 1);
-  return getModel(
-    provider as ProviderKey,
-    modelId as ModelIdKey<ProviderKey>,
-  ) as AnyModel;
+/**
+ * Parse a "provider/modelId" string. Exported because the compaction wiring in
+ * app.ts needs the same parsing logic for its bound-session summarize fn.
+ */
+export function parseModelString(s: string | undefined): { provider: string; modelId: string } | null {
+  if (!s) return null;
+  const slash = s.indexOf("/");
+  if (slash === -1) return null;
+  return { provider: s.slice(0, slash), modelId: s.slice(slash + 1) };
 }
 
 export interface SessionRunnerConfig {
-  /** Model alias ("sonnet"/"haiku"/"opus") or "provider/modelId". */
-  model: string;
+  /** Optional "provider/modelId" string. When omitted, the session uses pi's settings default. */
+  model?: string;
 }
 
 export interface RunQueryCallbacks {
@@ -101,6 +74,13 @@ async function downloadImage(url: string, destPath: string): Promise<void> {
 function isContextOverflowError(error: string): boolean {
   const lower = error.toLowerCase();
   return lower.includes("context") || lower.includes("token") || lower.includes("too long");
+}
+
+/** Surface context-overflow errors as a user-actionable message; pass others through. */
+function toFriendlyError(message: string): string {
+  return isContextOverflowError(message)
+    ? "Adventure history is too long. Edit history.md to shorten it."
+    : message;
 }
 
 /**
@@ -149,11 +129,8 @@ export function createSessionRunner(deps: {
   config: SessionRunnerConfig;
   fileOps?: FileOps;
   compactionService?: CompactionService;
-  /** Optional model override; primarily for tests. */
-  modelOverride?: AnyModel;
 }) {
   const { config, fileOps, compactionService } = deps;
-  const model = deps.modelOverride ?? resolveModel(config.model);
 
   async function runQuery(params: RunQueryParams): Promise<void> {
     const { systemPrompt, playerMessage, adventurePath, abortController } = params;
@@ -204,7 +181,7 @@ export function createSessionRunner(deps: {
       cwd: adventurePath,
       agentDir: getAgentDir(),
       systemPrompt: fullSystemPrompt,
-      noExtensions: true,
+      noExtensions: false,
       noSkills: true,
       noPromptTemplates: true,
       noThemes: true,
@@ -221,11 +198,27 @@ export function createSessionRunner(deps: {
       customTools,
     });
 
-    // bindExtensions runs queued extension hooks. We have no extensions of our
-    // own but still call it so any contributed providers/models on the global
-    // registry are wired in. See pi-agent-migration.md gotcha #4.
+    // bindExtensions runs queued extension hooks so extension-registered
+    // providers/models become visible on session.modelRegistry. Model selection
+    // must happen after this; with no model configured, the session falls back
+    // to pi's settings default (defaultProvider/defaultModel).
     await session.bindExtensions({});
-    await session.setModel(model);
+
+    const parsed = parseModelString(config.model);
+    if (parsed) {
+      const model = session.modelRegistry.find(parsed.provider, parsed.modelId);
+      if (model) {
+        await session.setModel(model);
+      } else {
+        console.warn(
+          `[session-runner] model "${config.model}" not found in registry, using session default`,
+        );
+      }
+    } else if (config.model) {
+      console.warn(
+        `[session-runner] model "${config.model}" is malformed (expected "provider/modelId"), using session default`,
+      );
+    }
 
     let accumulatedText = "";
     let aborted = false;
@@ -274,10 +267,7 @@ export function createSessionRunner(deps: {
       }
 
       if (errorMessage) {
-        const friendly = isContextOverflowError(errorMessage)
-          ? "Adventure history is too long. Edit history.md to shorten it."
-          : errorMessage;
-        await params.onError(friendly);
+        await params.onError(toFriendlyError(errorMessage));
         return;
       }
 
@@ -285,10 +275,7 @@ export function createSessionRunner(deps: {
     } catch (err: unknown) {
       if (aborted) return;
       const message = err instanceof Error ? err.message : String(err);
-      const friendly = isContextOverflowError(message)
-        ? "Adventure history is too long. Edit history.md to shorten it."
-        : message;
-      await params.onError(friendly);
+      await params.onError(toFriendlyError(message));
     } finally {
       unsubscribe();
       abortController.signal.removeEventListener("abort", onAbort);
@@ -296,7 +283,7 @@ export function createSessionRunner(deps: {
     }
   }
 
-  return { runQuery, model };
+  return { runQuery };
 }
 
 export type SessionRunner = ReturnType<typeof createSessionRunner>;

--- a/packages/backend/tests/helpers/mock-session-runner.ts
+++ b/packages/backend/tests/helpers/mock-session-runner.ts
@@ -95,7 +95,6 @@ export function createMockSessionRunner(
 
   return {
     runQuery,
-    model: { provider: "mock", id: "mock", api: "mock" } as unknown as SessionRunner["model"],
     get calls() {
       return calls;
     },


### PR DESCRIPTION
- Defer model selection to after extension binding so providers registered by extensions are visible to the session
- Update SessionRunner to accept explicit model option
- Add comprehensive lore documentation: plan, notes, and retro
- Update project context (CLAUDE.md) with architecture clarifications